### PR TITLE
 feat: add robot photo sync flow and scroll long form menus

### DIFF
--- a/main/docs/team-robot-photo-sync-plan.md
+++ b/main/docs/team-robot-photo-sync-plan.md
@@ -1,0 +1,34 @@
+# Team Robot Photo Sync Plan
+
+## Current Structure
+- Project state is split between `event.json`, `team.db`, `match.db`, and the image cache managed by `ImageManager`.
+- Team and match scouting results sync as JSON through `ProvideResults`.
+- Static images already sync by name through `RequestImages` / `ProvideImages`, and tablets only request images they do not already have locally.
+
+## Feature Shape
+- Team Scouting uses a new `robotphoto` form control in `capture` mode.
+- Match Scouting uses the same `robotphoto` control in `display` mode, reading the configured source tag from the active team result.
+- Robot photo binaries stay out of SQLite and out of raw event JSON payloads. Only the stable photo key is stored in scouting results and DB fields.
+
+## Storage
+- Team tablets store captured robot photos in the existing local image cache.
+- Central stores the canonical event copy under `<project>/robot-photos`.
+- `event.json` keeps a small `robot_photos_` manifest with team number, key, file name, format, and update time.
+
+## Sync
+- Team tablets upload new robot photos alongside `ProvideResults` using `robotPhotos` attachments.
+- Central writes those files to the event directory before processing team results.
+- Match tablets discover required robot photo keys from synced team results and request only missing files through the existing image sync flow.
+- The image cache prevents re-downloading the same robot photo on later syncs.
+
+## Image Format
+- Robot photos are compressed in the renderer to WebP before storage or sync.
+- Compression target is a 720p bounding box:
+  - landscape up to `1280x720`
+  - portrait up to `720x1280`
+- WebP quality is `0.85`.
+- The image pipeline now carries MIME type and extension metadata so PNG field assets and WebP robot photos can coexist.
+
+## Testing
+- Renderer bundle and main TypeScript compile pass through `npm run build` in `main/`.
+- Existing automated tests pass through `npx vitest run` in `main/`.

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -38,6 +38,7 @@ import { getNavData as getNavData, executeCommand, getInfoData, getSelectEventDa
          getMatchPredictorData,
          promptStringRequest,
          promptStringResponse,
+         storeRobotPhoto,
          getPreviewMatchDB,
          updatePreviewMatchDB,
          resetPreviewMatchDB
@@ -241,6 +242,7 @@ app.on("ready", () => {
     ipcMain.on('execute-command', (event, ...args) => { executeCommand('execute-command', ...args)}) ;
     ipcMain.on('set-tablet-name-purpose', (event, ...args) => { setTabletNamePurpose('set-table-name-purpose', ...args)}) ;
     ipcMain.on('provide-result', (event, ...args) => { provideResult('provide-result', ...args)}) ;
+    ipcMain.on('store-robot-photo', (event, ...args) => { storeRobotPhoto('store-robot-photo', ...args)}) ;
     ipcMain.on('send-match-col-config', (event, ...args) => { sendMatchColConfig('send-match-col-config', ...args)}) ;
     ipcMain.on('send-team-col-config', (event, ...args) => { sendTeamColConfig('send-team-col-config', ...args)}) ;
     ipcMain.on('get-team-list', (event, ...args) => { getTeamList('get-team-list', ...args)}) ;

--- a/main/src/main/apps/scbase.ts
+++ b/main/src/main/apps/scbase.ts
@@ -134,15 +134,9 @@ export abstract class SCBase {
 	}
 
 	public sendImageData(image: string) {
-		let ret : IPCImageResponse = {
-			newname: undefined,
-			name: image, 
-			data: this.getImageData(image)
-		}
-
+		let ret = this.getImageResponse(image) ;
 		if (!ret.data) {
-			ret.newname = 'missing' ;
-			ret.data = this.getImageData('missing') ;
+			ret = this.getImageResponse('missing', image) ;
 		}
 		this.sendToRenderer('send-image-data', ret) ;
 	}	
@@ -384,6 +378,17 @@ export abstract class SCBase {
 		
 		let data: string  = fs.readFileSync(datafile).toString('base64');
 		return data ;
+	}
+
+	protected getImageResponse(name: string, requestedName?: string) : IPCImageResponse {
+		const info = this.image_mgr_.getImageInfo(name) ;
+		return {
+			newname: requestedName && requestedName !== name ? name : undefined,
+			name: requestedName ?? name,
+			data: info ? fs.readFileSync(info.path).toString('base64') : '',
+			mimeType: info?.mimeType ?? 'image/png',
+			extension: info?.extension ?? 'png',
+		} ;
 	}
 
 	public splitterChanged(value: number) {

--- a/main/src/main/apps/sccentral.ts
+++ b/main/src/main/apps/sccentral.ts
@@ -15,7 +15,7 @@ import { StatBotics } from "../extnet/statbotics";
 import { TabletData } from "../project/tabletmgr";
 import { ManualMatchData } from "../project/matchmgr";
 	import { FormManager } from "../project/formmgr";
-	import { IPCAppType, IPCChange, IPCCheckDBViewFormula, IPCColumnDesc, IPCDatabaseData, IPCDataSet, IPCGraphConfig, IPCNamedDataValue, IPCPickListConfig, IPCProjColumnsConfig, IPCPromptStringRequest, IPCPromptStringResponse, IPCScoutResult, IPCScoutResults, IPCTeamInfo, IPCTypedDataValue } from "../../shared/ipc";
+	import { IPCAppType, IPCChange, IPCCheckDBViewFormula, IPCColumnDesc, IPCDatabaseData, IPCDataSet, IPCGraphConfig, IPCNamedDataValue, IPCPickListConfig, IPCProjColumnsConfig, IPCPromptStringRequest, IPCPromptStringResponse, IPCRobotPhotoManifestEntry, IPCRobotPhotoUpload, IPCScoutResult, IPCScoutResults, IPCSyncedImageData, IPCTeamInfo, IPCTypedDataValue } from "../../shared/ipc";
 	import { UDPBroadcast } from "../sync/udpbroadcast";
 	import { SCCoachCentralBaseApp } from "./sccoachcentralbase";
 
@@ -1889,17 +1889,20 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 	private handleRequestRequestImages(p: PacketObj): PacketObj {
 		let obj : string[] = JSON.parse(p.payloadAsString()) as string[] ;
-		let retdata : any = {} ;
+		let retdata : { [name: string]: IPCSyncedImageData } = {} ;
 
 		for(let img of obj) {
-			let path = this.image_mgr_.getImage(img) ;
-			let imdata = Buffer.from('') ;
-			if (path) {
-				let imdata2 = fs.readFileSync(path) ;
-				imdata = Buffer.from(imdata2) ;
+			let info = this.image_mgr_.getImageInfo(img) ;
+			if (!info) {
+				info = this.image_mgr_.getImageInfo('missing') ;
 			}
-
-			retdata[img] = imdata.toString('base64') ;
+			if (info) {
+				retdata[img] = {
+					data: fs.readFileSync(info.path).toString('base64'),
+					mimeType: info.mimeType,
+					extension: info.extension,
+				} ;
+			}
 		}
 
 		let data: Uint8Array = new Uint8Array(0);
@@ -2044,6 +2047,7 @@ export class SCCentral extends SCCoachCentralBaseApp {
 	private handleProvideResults(p: PacketObj): PacketObj {
 		try {
 			let obj : IPCScoutResults = JSON.parse(p.payloadAsString()) as IPCScoutResults ;
+			this.persistRobotPhotos(obj.robotPhotos || []) ;
 			this.project!.data_mgr_?.processResults(obj)
 				.then((count) => {
 					this.logger_.info(`processed ${count} synced ${obj.purpose} results from tablet '${obj.tablet}'`) ;
@@ -2074,6 +2078,44 @@ export class SCCentral extends SCCoachCentralBaseApp {
 				)
 			);
 		}
+	}
+
+	private persistRobotPhotos(photos: IPCRobotPhotoUpload[]) {
+		if (!this.project || !this.project.info || photos.length === 0) {
+			return ;
+		}
+
+		const dir = path.join(this.project.location, 'robot-photos') ;
+		fs.mkdirSync(dir, { recursive: true }) ;
+
+		for (const photo of photos) {
+			const fileName = `${photo.key}.${photo.extension}` ;
+			const fullPath = path.join(dir, fileName) ;
+			fs.writeFileSync(fullPath, Buffer.from(photo.data, 'base64')) ;
+
+			let entry = this.project.info.robot_photos_.find((one) => one.teamNumber === photo.teamNumber) ;
+			if (!entry) {
+				entry = {
+					teamNumber: photo.teamNumber,
+					key: photo.key,
+					fileName: fileName,
+					mimeType: photo.mimeType,
+					extension: photo.extension,
+					updatedAt: Date.now(),
+				} as IPCRobotPhotoManifestEntry ;
+				this.project.info.robot_photos_.push(entry) ;
+			}
+			else {
+				entry.key = photo.key ;
+				entry.fileName = fileName ;
+				entry.mimeType = photo.mimeType ;
+				entry.extension = photo.extension ;
+				entry.updatedAt = Date.now() ;
+			}
+		}
+
+		this.image_mgr_.setExtraImageDirs([dir]) ;
+		this.project.writeEventFile() ;
 	}
 
 	private handleRequestProject(p: PacketObj): PacketObj | undefined {

--- a/main/src/main/apps/sccoach.ts
+++ b/main/src/main/apps/sccoach.ts
@@ -7,7 +7,7 @@ import { PacketObj } from "../sync/packetobj";
 import { PacketType } from "../sync/packettypes";
 import { Project } from "../project/project";
 import { SCCoachCentralBaseApp } from "./sccoachcentralbase";
-import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCImageItem } from "../../shared/ipc";
+import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCImageItem, IPCSyncedImageData } from "../../shared/ipc";
 
 export class SCCoach extends SCCoachCentralBaseApp {
     private static readonly lastEventLoaded: string = 'coach-last-event-loaded' ;
@@ -450,8 +450,8 @@ export class SCCoach extends SCCoachCentralBaseApp {
             return '' ;
         }
 
-        if (/\.png$/i.test(ret)) {
-            ret = ret.replace(/\.png$/i, '') ;
+        if (/\.(png|webp)$/i.test(ret)) {
+            ret = ret.replace(/\.(png|webp)$/i, '') ;
         }
 
         return ret.trim() ;
@@ -619,12 +619,17 @@ export class SCCoach extends SCCoachCentralBaseApp {
 
             case PacketType.ProvideImages:
                 try {
-                    let obj = JSON.parse(p.payloadAsString()) as { [name: string]: string } ;
+                    let obj = JSON.parse(p.payloadAsString()) as { [name: string]: string | IPCSyncedImageData } ;
                     for (let imname of Object.keys(obj)) {
                         let imdata = obj[imname] ;
                         let norm = this.normalizeImageName(imname) ;
                         if (norm.length > 0) {
-                            this.image_mgr_.addImageWithData(norm, imdata) ;
+                            if (typeof imdata === 'string') {
+                                this.image_mgr_.addImageWithData(norm, imdata, 'png') ;
+                            }
+                            else {
+                                this.image_mgr_.addImageWithData(norm, imdata.data, imdata.extension) ;
+                            }
                         }
                     }
                 }

--- a/main/src/main/apps/sccoachcentralbase.ts
+++ b/main/src/main/apps/sccoachcentralbase.ts
@@ -5,6 +5,7 @@ import { Project } from "../project/project";
 import { BAMatch, BATeam } from "../extnet/badata";
 import { DataRecord } from "../model/datarecord";
 import { generateAutoAnalysisData } from "../project/autoanalysis";
+import * as path from "path";
 
 export abstract class SCCoachCentralBaseApp extends SCBase {
     private project_?: Project = undefined;
@@ -23,6 +24,20 @@ export abstract class SCCoachCentralBaseApp extends SCBase {
 
     protected set project(proj: Project | undefined) {
         this.project_ = proj ;
+        let isCentral = false ;
+        try {
+            isCentral = this.applicationType === 'central' ;
+        }
+        catch {
+            isCentral = false ;
+        }
+
+        if (isCentral && proj) {
+            this.image_mgr_.setExtraImageDirs([path.join(proj.location, 'robot-photos')]) ;
+        }
+        else {
+            this.image_mgr_.setExtraImageDirs([]) ;
+        }
     }
 
     protected get color() : string {

--- a/main/src/main/apps/scscout.ts
+++ b/main/src/main/apps/scscout.ts
@@ -8,7 +8,7 @@ import { PacketObj } from "../sync/packetobj";
 import { PacketType } from "../sync/packettypes";
 import { MatchTablet, PlayoffAssignment, TeamTablet } from "../project/tabletmgr";
 import { kMatchAlliances } from '../../shared/playoffs';
-import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCFormScoutData, IPCImageItem, IPCNamedDataValue, IPCPlayoffStatus, IPCScoutResult, IPCScoutResults, IPCSection, IPCTabletDefn } from "../../shared/ipc";
+import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCFormScoutData, IPCImageItem, IPCNamedDataValue, IPCPlayoffStatus, IPCRobotPhotoCaptureRequest, IPCRobotPhotoItem, IPCRobotPhotoState, IPCRobotPhotoUpload, IPCScoutResult, IPCScoutResults, IPCSection, IPCSyncedImageData, IPCTabletDefn } from "../../shared/ipc";
 
 export class SCScoutInfo {
     public tablet_? : string ;
@@ -21,12 +21,14 @@ export class SCScoutInfo {
     public matchlist_? : MatchTablet[] ;
     public results_ : IPCScoutResult[] ;
     public team_results_cache_ : IPCScoutResult[] ;
+    public robot_photos_ : IPCRobotPhotoState[] ;
     public playoff_assignments_? : PlayoffAssignment[] ;
     public playoff_status_? : IPCPlayoffStatus ;
 
     constructor() {
         this.results_ = [] ;
         this.team_results_cache_ = [] ;
+        this.robot_photos_ = [] ;
     }
 }
 
@@ -68,6 +70,7 @@ export class SCScout extends SCBase {
 
     private ipaddr_: string = SCScout.defaultSyncIPAddr ;
     private port_ : number = SCScout.defaultSyncPort ;
+    private last_robot_photo_sync_keys_ : string[] = [] ;
 
     private team_number_ : number = 1425 ;
 
@@ -382,6 +385,7 @@ export class SCScout extends SCBase {
         this.info_.tablet_ = undefined ;
         this.info_.results_ = [];
         this.info_.team_results_cache_ = [] ;
+        this.info_.robot_photos_ = [] ;
         this.info_.uuid_ = undefined ;
         this.info_.evname_ = undefined ;
         this.info_.teamform_ = undefined ;
@@ -398,6 +402,7 @@ export class SCScout extends SCBase {
         this.team_list_received_ = false ;
         this.playoff_assignment_received_ = false ;
         this.playoff_status_received_ = false ;
+        this.last_robot_photo_sync_keys_ = [] ;
 
         this.sendToRenderer('tablet-title', 'NOT ASSIGNED') ;
 
@@ -526,6 +531,7 @@ export class SCScout extends SCBase {
             reversed: this.reversed_,
             color: this.alliance_,
             title: this.current_scout_,
+            eventUuid: this.info_.uuid_,
             scoutItem: this.current_scout_,
         }
 
@@ -558,8 +564,34 @@ export class SCScout extends SCBase {
     }
 
     public sendImageData(image: string) {
-		this.sendToRenderer('send-image-data', { name: image, data: this.getImageData(image) }) ;
+		super.sendImageData(image) ;
 	}
+
+    public storeRobotPhoto(request: IPCRobotPhotoCaptureRequest) {
+        this.image_mgr_.addImageWithData(request.key, request.data, request.extension) ;
+        const updatedAt = Date.now() ;
+        const existing = this.info_.robot_photos_.find((entry) => entry.key === request.key) ;
+        if (existing) {
+            existing.item = request.item ;
+            existing.teamNumber = request.teamNumber ;
+            existing.mimeType = request.mimeType ;
+            existing.extension = request.extension ;
+            existing.uploaded = false ;
+            existing.updatedAt = updatedAt ;
+        }
+        else {
+            this.info_.robot_photos_.push({
+                item: request.item,
+                key: request.key,
+                teamNumber: request.teamNumber,
+                mimeType: request.mimeType,
+                extension: request.extension,
+                uploaded: false,
+                updatedAt: updatedAt,
+            }) ;
+        }
+        this.writeEventFile() ;
+    }
 
     public sendMatchForm() {
         let ret = {
@@ -791,8 +823,13 @@ export class SCScout extends SCBase {
         else if (p.type_ === PacketType.ProvideImages) {
             let obj = JSON.parse(p.payloadAsString()) ;
             for(let imname of Object.keys(obj)) {
-                let imdata = obj[imname] ;
-                this.image_mgr_.addImageWithData(imname, imdata) ;
+                let imdata = obj[imname] as string | IPCSyncedImageData ;
+                if (typeof imdata === 'string') {
+                    this.image_mgr_.addImageWithData(imname, imdata, 'png') ;
+                }
+                else {
+                    this.image_mgr_.addImageWithData(imname, imdata.data, imdata.extension) ;
+                }
             }
             ret = this.getMissingData() ;  
         }
@@ -830,6 +867,8 @@ export class SCScout extends SCBase {
             this.conn_?.close() ;
         }
         else if (p.type_ === PacketType.ReceivedResults) {
+            this.markRobotPhotosUploaded(this.last_robot_photo_sync_keys_) ;
+            this.last_robot_photo_sync_keys_ = [] ;
             this.conn_?.send(new PacketObj(PacketType.GoodbyeFromScouter, Buffer.from(this.info_.tablet_!))) ;
             this.conn_?.close() ;
         }
@@ -845,12 +884,11 @@ export class SCScout extends SCBase {
         let obj : IPCScoutResults = {
             tablet: this.info_.tablet_!,
             purpose: this.info_.purpose_!,
-            results: this.info_.results_
+            results: this.info_.results_,
+            robotPhotos: this.collectPendingRobotPhotos()
         } ;
 
         let jsonstr = JSON.stringify(obj) ;
-        let buffer = Buffer.from(jsonstr) ;
-        let jsonstr2 = buffer.toString() ;
         this.conn_?.send(new PacketObj(PacketType.ProvideResults, Buffer.from(jsonstr))) ;
     }
 
@@ -897,8 +935,8 @@ export class SCScout extends SCBase {
             return '' ;
         }
 
-        if (/\.png$/i.test(ret)) {
-            ret = ret.replace(/\.png$/i, '') ;
+        if (/\.(png|webp)$/i.test(ret)) {
+            ret = ret.replace(/\.(png|webp)$/i, '') ;
         }
 
         return ret.trim() ;
@@ -945,7 +983,8 @@ export class SCScout extends SCBase {
     private needImages() : string [] {
         let images: string[] = [ 
                 ...this.getRequiredImagesFromForm(this.info_.teamform_), 
-                ... this.getRequiredImagesFromForm(this.info_.matchform_)] ;
+                ... this.getRequiredImagesFromForm(this.info_.matchform_),
+                ... this.getNeededRobotPhotoKeys()] ;
 
         let imlist = [...new Set(images)];
         let ret: string[] = [] ;
@@ -1223,6 +1262,9 @@ export class SCScout extends SCBase {
         if (!this.info_.team_results_cache_) {
             this.info_.team_results_cache_ = [] ;
         }
+        if (!this.info_.robot_photos_) {
+            this.info_.robot_photos_ = [] ;
+        }
 
         return ret ;
     }
@@ -1257,6 +1299,102 @@ export class SCScout extends SCBase {
         }
 
         this.info_.team_results_cache_.push(result) ;
+    }
+
+    private collectPendingRobotPhotos() : IPCRobotPhotoUpload[] {
+        let ret : IPCRobotPhotoUpload[] = [] ;
+        this.last_robot_photo_sync_keys_ = [] ;
+
+        for (const entry of this.info_.robot_photos_) {
+            if (entry.uploaded) {
+                continue ;
+            }
+
+            const info = this.image_mgr_.getImageInfo(entry.key) ;
+            if (!info || !fs.existsSync(info.path)) {
+                continue ;
+            }
+
+            ret.push({
+                item: entry.item,
+                key: entry.key,
+                teamNumber: entry.teamNumber,
+                data: fs.readFileSync(info.path).toString('base64'),
+                mimeType: entry.mimeType,
+                extension: entry.extension,
+            }) ;
+            this.last_robot_photo_sync_keys_.push(entry.key) ;
+        }
+
+        return ret ;
+    }
+
+    private markRobotPhotosUploaded(keys: string[]) {
+        if (!keys || keys.length === 0) {
+            return ;
+        }
+
+        for (const entry of this.info_.robot_photos_) {
+            if (keys.includes(entry.key)) {
+                entry.uploaded = true ;
+            }
+        }
+        this.writeEventFile() ;
+    }
+
+    private getRobotPhotoCaptureTags(form: IPCForm | undefined) : string[] {
+        if (!form || !form.sections) {
+            return [] ;
+        }
+
+        let tags: string[] = [] ;
+        for (const section of form.sections) {
+            for (const item of section.items) {
+                if (item.type === 'robotphoto') {
+                    const robot = item as IPCRobotPhotoItem ;
+                    if (robot.mode === 'capture' && robot.tag.length > 0) {
+                        tags.push(robot.tag) ;
+                    }
+                }
+            }
+        }
+
+        return [...new Set(tags)] ;
+    }
+
+    private getNeededRobotPhotoKeys() : string[] {
+        const photoTags = this.getRobotPhotoCaptureTags(this.info_.teamform_) ;
+        if (photoTags.length === 0) {
+            return [] ;
+        }
+
+        const ret = new Set<string>() ;
+        const inspect = (result: IPCScoutResult | undefined) => {
+            if (!result || !Array.isArray(result.data)) {
+                return ;
+            }
+
+            for (const one of result.data) {
+                if (!photoTags.includes(one.tag) || one.value.type !== 'string' || typeof one.value.value !== 'string') {
+                    continue ;
+                }
+
+                const key = this.normalizeImageName(one.value.value) ;
+                if (key.length > 0 && !this.image_mgr_.hasImage(key)) {
+                    ret.add(key) ;
+                }
+            }
+        } ;
+
+        for (const result of this.info_.team_results_cache_) {
+            inspect(result) ;
+        }
+
+        for (const result of this.info_.results_) {
+            inspect(result) ;
+        }
+
+        return [...ret] ;
     }
 
     private writeEventFile() : Error | undefined {

--- a/main/src/main/imagemgr.ts
+++ b/main/src/main/imagemgr.ts
@@ -1,23 +1,22 @@
-import { app }  from  'electron' ;
+import { app } from 'electron' ;
 import * as path from 'path' ;
 import * as fs from 'fs' ;
+import { IPCImageExtension } from '../shared/ipc' ;
+
+export interface ImageInfo {
+    path: string ;
+    extension: IPCImageExtension ;
+    mimeType: string ;
+}
 
 export class ImageManager {
     private imagedir_? : string ;
     private appimagedir_? : string ;
-    private imagemap_ : Map<string, string> = new Map() ;
+    private extraimagedirs_ : string[] = [] ;
+    private imagemap_ : Map<string, ImageInfo> = new Map() ;
 
     constructor(appname: string, appimagedir?: string) {
-        //
-        // This is for the central (server).  The application comes installed with the blank image
-        // and a set of field images.
-        //
         this.appimagedir_ = appimagedir ;
-
-        //
-        // This is for any user imported images.  This is also used on the scouter side to store all
-        // images received during the sync from the central server.
-        //
         this.imagedir_ = this.findUserImageDir(appname) ;
         if (this.imagedir_) {
             this.createImageDir() ;
@@ -36,6 +35,15 @@ export class ImageManager {
         if (this.appimagedir_) {
             this.scanImageDir(this.appimagedir_) ;
         }
+
+        for (const dir of this.extraimagedirs_) {
+            this.scanImageDir(dir) ;
+        }
+    }
+
+    public setExtraImageDirs(dirs: string[]) {
+        this.extraimagedirs_ = dirs.filter((dir) => typeof dir === 'string' && dir.length > 0) ;
+        this.rescanImageDirs() ;
     }
 
     public getImageNames() : string[] {
@@ -47,40 +55,42 @@ export class ImageManager {
     }
 
     public getImage(name : string) : string | undefined {
-        // Get the image path for the given name
-        if (this.imagemap_.has(name)) {
-            return this.imagemap_.get(name) ;
-        }
-        return undefined ;
+        return this.imagemap_.get(name)?.path ;
+    }
+
+    public getImageInfo(name : string) : ImageInfo | undefined {
+        return this.imagemap_.get(name) ;
     }
 
     public addImage(imagePath : string) : boolean | string {
-        // Add an image to the image directory
         if (this.imagedir_) {
             let name = path.basename(imagePath) ;
             let mname = path.parse(name).name ;
             const destPath = path.join(this.imagedir_, name) ;
             fs.copyFileSync(imagePath, destPath) ;
-            this.imagemap_.set(mname, destPath) ;
+            const info = this.createImageInfo(destPath) ;
+            if (!info) {
+                return false ;
+            }
+            this.imagemap_.set(mname, info) ;
             return mname ;
         }
         return false ;
     }
 
-    public addImageWithData(name : string, data : string) {
+    public addImageWithData(name : string, data : string, extension : IPCImageExtension = 'png') {
         if (this.imagedir_) {
-            const destPath = path.join(this.imagedir_, name) + '.png' ;
+            const destPath = path.join(this.imagedir_, name) + '.' + extension ;
             let buf = Buffer.from(data, 'base64') ;
             fs.writeFileSync(destPath, buf) ;
-            this.imagemap_.set(name, destPath) ;
+            const info = this.createImageInfo(destPath) ;
+            if (info) {
+                this.imagemap_.set(name, info) ;
+            }
         }
     }
 
-    private findUserImageDir(appname: string) : string | undefined{
-        //
-        // Use Electron's per-user app data directory (cross-platform) instead of
-        // relying on environment variables like HOMEDIR (which is not set on macOS).
-        //
+    private findUserImageDir(appname: string) : string | undefined {
         try {
             return path.join(app.getPath('userData'), 'images', appname) ;
         }
@@ -90,9 +100,8 @@ export class ImageManager {
     }
 
     private createImageDir() {
-        // Create the image directory if it doesn't exist
         if (this.imagedir_ && !fs.existsSync(this.imagedir_)) {
-            fs.mkdirSync(this.imagedir_, { recursive : true}) ;
+            fs.mkdirSync(this.imagedir_, { recursive : true }) ;
             if (!fs.existsSync(this.imagedir_)) {
                 this.imagedir_ = undefined ;
             }
@@ -100,13 +109,17 @@ export class ImageManager {
     }
 
     private scanImageDir(dir: string) {
-        // Scan the image directory for images
         if (dir && fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
             const files = fs.readdirSync(dir) ;
             for (const file of files) {
-                const filePath = path.join(dir!, file) ;
-                if (fs.statSync(filePath).isFile() && file.toLowerCase().endsWith('.png')) {
-                    this.imagemap_.set(path.parse(file).name, filePath) ;
+                const filePath = path.join(dir, file) ;
+                if (!fs.statSync(filePath).isFile()) {
+                    continue ;
+                }
+
+                const info = this.createImageInfo(filePath) ;
+                if (info) {
+                    this.imagemap_.set(path.parse(file).name, info) ;
                 }
             }
         }
@@ -114,12 +127,43 @@ export class ImageManager {
 
     public removeAllImages() {
         if (this.imagedir_ && fs.existsSync(this.imagedir_) && fs.statSync(this.imagedir_).isDirectory()) {
-            for(let file of fs.readdirSync(this.imagedir_!)) {
-                const filePath = path.join(this.imagedir_!, file) ;
+            for (let file of fs.readdirSync(this.imagedir_)) {
+                const filePath = path.join(this.imagedir_, file) ;
                 fs.unlinkSync(filePath) ;
             }
         }
 
-        this.rescanImageDirs() ;        
+        this.rescanImageDirs() ;
+    }
+
+    private createImageInfo(filePath: string) : ImageInfo | undefined {
+        const extension = this.extensionFromPath(filePath) ;
+        if (!extension) {
+            return undefined ;
+        }
+
+        return {
+            path: filePath,
+            extension: extension,
+            mimeType: this.mimeTypeFromExtension(extension),
+        } ;
+    }
+
+    private extensionFromPath(filePath: string) : IPCImageExtension | undefined {
+        const ext = path.extname(filePath).toLowerCase() ;
+        if (ext === '.png') {
+            return 'png' ;
+        }
+        if (ext === '.webp') {
+            return 'webp' ;
+        }
+        return undefined ;
+    }
+
+    private mimeTypeFromExtension(extension: IPCImageExtension) : string {
+        if (extension === 'webp') {
+            return 'image/webp' ;
+        }
+        return 'image/png' ;
     }
 }

--- a/main/src/main/ipchandlers.ts
+++ b/main/src/main/ipchandlers.ts
@@ -3,7 +3,7 @@ import { SCCentral } from "./apps/sccentral";
 import { SCScout } from "./apps/scscout";
 import { SCCoach } from "./apps/sccoach";
 import { TabletData } from "./project/tabletmgr";
-import { IPCAutoAnalysisConfig, IPCAutoAnalysisRequest, IPCCheckDBViewFormula, IPCDataSet, IPCGetTeamsOptions, IPCGraphConfig, IPCMatchPredictorRequest, IPCNamedDataValue, IPCPickListConfig, IPCPredictConfig, IPCProjColumnsConfig, IPCPromptStringRequest, IPCPromptStringResponse, IPCTeamInfo } from "../shared/ipc";
+import { IPCAutoAnalysisConfig, IPCAutoAnalysisRequest, IPCCheckDBViewFormula, IPCDataSet, IPCGetTeamsOptions, IPCGraphConfig, IPCMatchPredictorRequest, IPCNamedDataValue, IPCPickListConfig, IPCPredictConfig, IPCProjColumnsConfig, IPCPromptStringRequest, IPCPromptStringResponse, IPCRobotPhotoCaptureRequest, IPCTeamInfo } from "../shared/ipc";
 import { SCCoachCentralBaseApp } from "./apps/sccoachcentralbase";
 
 function isScoutType() : boolean {
@@ -649,6 +649,20 @@ export async function provideResult(cmd: string, ...args: any[]) {
             scappbase.logger_.error({ message: 'renderer -> main invalid args', args: {cmd: cmd, cmdargs: args}});             
         }
     } 
+}
+
+// store-robot-photo data:IPCRobotPhotoCaptureRequest
+export async function storeRobotPhoto(cmd: string, ...args: any[]) {
+    if (scappbase && isScoutType()) {
+        scappbase.logger_.silly({ message: 'renderer -> main', args: {cmd: cmd, cmdargs: args}});
+        let scout : SCScout = scappbase as SCScout ;
+        if (args.length === 1 && typeof args[0] === 'object') {
+            scout.storeRobotPhoto(args[0] as IPCRobotPhotoCaptureRequest) ;
+        }
+        else {
+            scappbase.logger_.error({ message: 'renderer -> main invalid args', args: {cmd: cmd, cmdargs: args}});
+        }
+    }
 }
 
 // set-team-data data:ProjColConfig

--- a/main/src/main/preload.ts
+++ b/main/src/main/preload.ts
@@ -50,6 +50,7 @@ contextBridge.exposeInMainWorld( 'scoutingAPI', {
         'get-match-status',               // views/matchstatus.ts
         'set-tablet-name-purpose',        // views/selecttablet/selecttablet.ts
 	        'provide-result',                 // views/forms/scoutformview.ts
+        'store-robot-photo',              // views/forms/controls/robotphotoctrl.ts
 
 	        'get-preview-match-db',           // views/forms/scoutformview.ts (central match form preview)
 	        'update-preview-match-db',        // views/forms/scoutformview.ts (central match form preview)

--- a/main/src/main/project/formmgr.ts
+++ b/main/src/main/project/formmgr.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import { DataManager } from "./datamgr";
 import { dialog } from "electron";
-import { IPCChoice, IPCChoicesItem, IPCColumnDesc, IPCForm, IPCFormControlType, IPCFormItem, IPCFormPurpose } from "../../shared/ipc";
+import { IPCChoice, IPCChoicesItem, IPCColumnDesc, IPCForm, IPCFormControlType, IPCFormItem, IPCFormPurpose, IPCRobotPhotoItem } from "../../shared/ipc";
 import { TabletDB } from "../../shared/tabletdb";
 import { RulesEngine } from "../../shared/rulesengine";
 
@@ -314,6 +314,9 @@ export class FormManager extends Manager {
 							if (item.type === "image" || item.type === "label" || item.type === "box") {
 								// Skip any control that does not provide data, as these are not stored in the database
 								continue;
+							}
+							if (item.type === "robotphoto" && (item as IPCRobotPhotoItem).mode === 'display') {
+								continue ;
 							}
 
 						let choices: IPCChoice[] | undefined = undefined ;

--- a/main/src/main/project/projectinfo.ts
+++ b/main/src/main/project/projectinfo.ts
@@ -1,4 +1,4 @@
-import { IPCPlayoffStatus } from "../../shared/ipc";
+import { IPCPlayoffStatus, IPCRobotPhotoManifestEntry } from "../../shared/ipc";
 import { BAEvent, BAMatch, BATeam } from "../extnet/badata";
 import { DataModelInfo } from "../model/datamodel";
 import { DataInfo } from "./datamgr";
@@ -33,6 +33,7 @@ export class ProjectInfo {
         alliances: [ undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined ],
         outcomes: { m1: undefined, m2: undefined, m3: undefined, m4: undefined, m5: undefined, m6: undefined, m7: undefined, m8: undefined, m9: undefined, m10: undefined, m11: undefined, m12: undefined, m13: undefined, m14: undefined, m15: undefined, m16: undefined }
     } ;
+    public robot_photos_ : IPCRobotPhotoManifestEntry[] = [] ;          // Per-event manifest for canonical robot photos
 
     constructor() {
         this.locked_ = false ;

--- a/main/src/shared/ipc.ts
+++ b/main/src/shared/ipc.ts
@@ -28,7 +28,7 @@ export interface IPCTabletDefn {
     purpose: IPCFormPurpose | undefined;
 }
 
-export type IPCFormControlType = 'label' | 'text' | 'textarea' | 'boolean' | 'updown' | 'choice' | 'select' | 'timer' | 'stopwatch' | 'box' | 'image' | 'autoplan' | 'autoselector' ;
+export type IPCFormControlType = 'label' | 'text' | 'textarea' | 'boolean' | 'updown' | 'choice' | 'select' | 'timer' | 'stopwatch' | 'box' | 'image' | 'autoplan' | 'autoselector' | 'robotphoto' ;
 
 export interface IPCFormItem {
     type: IPCFormControlType ;
@@ -57,6 +57,14 @@ export interface IPCImageItem extends IPCFormItem {
     field: boolean ;
     mirrorx: boolean ;
     mirrory: boolean ;
+}
+
+export type IPCRobotPhotoMode = 'capture' | 'display' ;
+export type IPCImageExtension = 'png' | 'webp' ;
+
+export interface IPCRobotPhotoItem extends IPCFormItem {
+    mode: IPCRobotPhotoMode ;
+    sourceTag?: string ;
 }
 
 export interface IPCAutoPlanItem extends IPCFormItem {
@@ -198,6 +206,7 @@ export interface IPCFormScoutData {
     mirrory? : boolean ;
     color? : string ;
     title? : string ;
+    eventUuid?: string ;
     scoutItem?: string ;
     activeTeamResult?: IPCScoutResult ;
 }
@@ -211,6 +220,7 @@ export interface IPCScoutResults {
     tablet: string ;
     purpose: string ;
     results: IPCScoutResult[] ;
+    robotPhotos?: IPCRobotPhotoUpload[] ;
 }
 
 export interface IPCAutoAnalysisNode {
@@ -313,6 +323,51 @@ export interface IPCImageResponse {
     name: string ;
     newname: string | undefined ;
     data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCSyncedImageData {
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoCaptureRequest {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoUpload {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoState {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+    uploaded: boolean ;
+    updatedAt: number ;
+}
+
+export interface IPCRobotPhotoManifestEntry {
+    teamNumber: number ;
+    key: string ;
+    fileName: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+    updatedAt: number ;
 }
 
 export interface IPCCheckDBViewFormula {

--- a/renderer/src/apps/imagesrc.ts
+++ b/renderer/src/apps/imagesrc.ts
@@ -12,7 +12,7 @@ export class ImageDataSource extends XeroMainProcessInterface {
     private static kMissingImageName = 'missing' ;    
 
     private image_names: string[] = [] ;                            // List of image names
-    private nameToImageMap_: Map<string, string> = new Map() ;      // Map of image name to base64 data
+    private nameToImageMap_: Map<string, IPCImageResponse> = new Map() ;
     private waiters: ImageWaiters[] = [] ;                          // List of promises waiting on images data
 
     constructor() {
@@ -33,12 +33,7 @@ export class ImageDataSource extends XeroMainProcessInterface {
     public getImageData(name: string) : Promise<IPCImageResponse> {
         let ret = new Promise<IPCImageResponse>((resolve, reject) => {
             if (this.nameToImageMap_.has(name)) {
-                let resp : IPCImageResponse = {
-                    name: name,
-                    data: this.nameToImageMap_.get(name)!,
-                    newname: undefined
-                };
-                resolve(resp) ;
+                resolve(this.nameToImageMap_.get(name)!) ;
             }
             else {
                 this.request('get-image-data', name) ;
@@ -61,6 +56,10 @@ export class ImageDataSource extends XeroMainProcessInterface {
         return this.getImageData(ImageDataSource.kMissingImageName) ;
     }
 
+    public buildDataUrl(image: IPCImageResponse) : string {
+        return `data:${image.mimeType};base64,${image.data}` ;
+    }
+
     private receivedImageNames(args: string[]) : void {
         this.image_names = args ;
         this.emit('image-names-updated', this.image_names) ;
@@ -68,10 +67,10 @@ export class ImageDataSource extends XeroMainProcessInterface {
 
     private receivedImageData(args:IPCImageResponse) : void {
         if (args.newname) {
-            this.nameToImageMap_.set(args.newname, args.data) ;
+            this.nameToImageMap_.set(args.newname, args) ;
         }
         else {
-            this.nameToImageMap_.set(args.name, args.data) ;
+            this.nameToImageMap_.set(args.name, args) ;
         }
         
         let processed = true ;

--- a/renderer/src/shared/ipc.ts
+++ b/renderer/src/shared/ipc.ts
@@ -28,7 +28,7 @@ export interface IPCTabletDefn {
     purpose: IPCFormPurpose | undefined;
 }
 
-export type IPCFormControlType = 'label' | 'text' | 'textarea' | 'boolean' | 'updown' | 'choice' | 'select' | 'timer' | 'stopwatch' | 'box' | 'image' | 'autoplan' | 'autoselector' ;
+export type IPCFormControlType = 'label' | 'text' | 'textarea' | 'boolean' | 'updown' | 'choice' | 'select' | 'timer' | 'stopwatch' | 'box' | 'image' | 'autoplan' | 'autoselector' | 'robotphoto' ;
 
 export interface IPCFormItem {
     type: IPCFormControlType ;
@@ -57,6 +57,14 @@ export interface IPCImageItem extends IPCFormItem {
     field: boolean ;
     mirrorx: boolean ;
     mirrory: boolean ;
+}
+
+export type IPCRobotPhotoMode = 'capture' | 'display' ;
+export type IPCImageExtension = 'png' | 'webp' ;
+
+export interface IPCRobotPhotoItem extends IPCFormItem {
+    mode: IPCRobotPhotoMode ;
+    sourceTag?: string ;
 }
 
 export interface IPCAutoPlanItem extends IPCFormItem {
@@ -198,6 +206,7 @@ export interface IPCFormScoutData {
     mirrory? : boolean ;
     color? : string ;
     title? : string ;
+    eventUuid?: string ;
     scoutItem?: string ;
     activeTeamResult?: IPCScoutResult ;
 }
@@ -211,6 +220,7 @@ export interface IPCScoutResults {
     tablet: string ;
     purpose: string ;
     results: IPCScoutResult[] ;
+    robotPhotos?: IPCRobotPhotoUpload[] ;
 }
 
 export interface IPCAutoAnalysisNode {
@@ -313,6 +323,51 @@ export interface IPCImageResponse {
     name: string ;
     newname: string | undefined ;
     data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCSyncedImageData {
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoCaptureRequest {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoUpload {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    data: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+}
+
+export interface IPCRobotPhotoState {
+    item: string ;
+    key: string ;
+    teamNumber: number ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+    uploaded: boolean ;
+    updatedAt: number ;
+}
+
+export interface IPCRobotPhotoManifestEntry {
+    teamNumber: number ;
+    key: string ;
+    fileName: string ;
+    mimeType: string ;
+    extension: IPCImageExtension ;
+    updatedAt: number ;
 }
 
 export interface IPCCheckDBViewFormula {

--- a/renderer/src/views/autoanalysis/autoanalysisview.ts
+++ b/renderer/src/views/autoanalysis/autoanalysisview.ts
@@ -700,7 +700,7 @@ export class AutoAnalysisView extends XeroView {
         try {
             const data = await this.app.imageSource!.getImageData(normalized) ;
             if (data && data.data) {
-                image.src = `data:image/png;base64,${data.data}` ;
+                image.src = this.app.imageSource!.buildDataUrl(data) ;
             }
         }
         catch {

--- a/renderer/src/views/forms/controls/autoplanctrl.ts
+++ b/renderer/src/views/forms/controls/autoplanctrl.ts
@@ -439,7 +439,7 @@ export class AutoPlanControl extends FormControl {
                     if (data.newname) {
                         item.fieldImage = data.newname;
                     }
-                    this.field_image_!.src = `data:image/png;base64,${data.data}`;
+                    this.field_image_!.src = this.image_src_.buildDataUrl(data);
                 }
             });
     }

--- a/renderer/src/views/forms/controls/autoselectorctrl.ts
+++ b/renderer/src/views/forms/controls/autoselectorctrl.ts
@@ -207,7 +207,7 @@ class AutoSelectorDialog extends XeroDialog {
                     if (data.newname) {
                         this.field_image_name_ = data.newname;
                     }
-                    this.field_.src = `data:image/png;base64,${data.data}`;
+                    this.field_.src = this.image_src_.buildDataUrl(data);
                 }
             })
             .catch(() => {

--- a/renderer/src/views/forms/controls/imagectrl.ts
+++ b/renderer/src/views/forms/controls/imagectrl.ts
@@ -67,9 +67,9 @@ export class ImageControl extends FormControl {
         return (this.item as IPCImageItem).field ;
     }
 
-    public setImageData(image: string) : void {
+    public setImageData(dataUrl: string) : void {
         if (this.image_) {
-            this.image_.src = `data:image/png;base64,${image}`
+            this.image_.src = dataUrl ;
         }
     }
 
@@ -87,7 +87,7 @@ export class ImageControl extends FormControl {
                         if (data.newname) {
                             item.image = data.newname ;
                         }
-                        this.setImageData(data.data) ;
+                        this.setImageData(this.image_src_.buildDataUrl(data)) ;
                         this.updateImageScale() ;
      
                     }

--- a/renderer/src/views/forms/controls/robotphotoctrl.ts
+++ b/renderer/src/views/forms/controls/robotphotoctrl.ts
@@ -1,0 +1,374 @@
+import { IPCFormScoutData, IPCImageResponse, IPCRobotPhotoCaptureRequest, IPCRobotPhotoItem, IPCScoutResult, IPCTypedDataValue } from "../../../shared/ipc.js";
+import { XeroRect } from "../../../shared/xerogeom.js";
+import { XeroView } from "../../xeroview.js";
+import { ImageDataSource } from "../../../apps/imagesrc.js";
+import { EditFormControlDialog } from "../dialogs/editformctrldialog.js";
+import { EditRobotPhotoDialog } from "../dialogs/editrobotphotodialog.js";
+import { FormControl } from "./formctrl.js";
+
+export class RobotPhotoControl extends FormControl {
+    private static readonly item_desc_ : IPCRobotPhotoItem = {
+        type: 'robotphoto',
+        tag: '',
+        x: 0,
+        y: 0,
+        width: 280,
+        height: 220,
+        color: 'black',
+        background: '#f3f4f6',
+        fontFamily: 'Arial',
+        fontSize: 20,
+        fontWeight: 'normal',
+        fontStyle: 'normal',
+        datatype: 'string',
+        transparent: false,
+        mode: 'capture',
+        sourceTag: '',
+    } ;
+
+    private image_src_ : ImageDataSource ;
+    private image_? : HTMLImageElement ;
+    private status_? : HTMLDivElement ;
+    private button_? : HTMLButtonElement ;
+    private input_? : HTMLInputElement ;
+    private current_key_? : string ;
+    private local_data_url_? : string ;
+
+    constructor(imsrc: ImageDataSource, view: XeroView, tag: string, bounds: XeroRect) {
+        super(view, RobotPhotoControl.item_desc_) ;
+        this.image_src_ = imsrc ;
+        this.setTag(tag) ;
+        this.setBounds(bounds) ;
+    }
+
+    protected copyObject() : FormControl {
+        return new RobotPhotoControl(this.image_src_, this.view, this.item.tag, this.bounds) ;
+    }
+
+    public createEditDialog(): EditFormControlDialog {
+        return new EditRobotPhotoDialog(this) ;
+    }
+
+    public getData() : IPCTypedDataValue | undefined {
+        if (this.robotItem.mode === 'display') {
+            return undefined ;
+        }
+
+        if (this.current_key_ && this.current_key_.length > 0) {
+            return {
+                type: 'string',
+                value: this.current_key_,
+            } ;
+        }
+
+        return {
+            type: 'null',
+            value: null,
+        } ;
+    }
+
+    public setData(data: IPCTypedDataValue) : void {
+        if (this.robotItem.mode !== 'capture') {
+            return ;
+        }
+
+        if (data.type === 'string' && typeof data.value === 'string' && data.value.length > 0) {
+            this.current_key_ = data.value ;
+            this.local_data_url_ = undefined ;
+            this.loadImageForKey(this.current_key_) ;
+        }
+        else {
+            this.current_key_ = undefined ;
+            this.local_data_url_ = undefined ;
+            this.renderState() ;
+        }
+    }
+
+    public updateFromItem(editing: boolean, scale: number, xoff: number, yoff: number) : void {
+        if (!this.ctrl) {
+            return ;
+        }
+
+        this.setPosition(scale, xoff, yoff, 900) ;
+        if (editing) {
+            if (this.status_) {
+                this.status_.innerText = this.robotItem.mode === 'capture' ? 'Robot Photo Capture' : `Robot Photo Display (${this.robotItem.sourceTag || 'unset'})` ;
+            }
+            return ;
+        }
+
+        if (this.robotItem.mode === 'display') {
+            this.refreshFromActiveTeamResult() ;
+        }
+        else if (this.current_key_ && !this.local_data_url_) {
+            this.loadImageForKey(this.current_key_) ;
+        }
+        else {
+            this.renderState() ;
+        }
+    }
+
+    public createForEdit(parent: HTMLElement, xoff: number, yoff:number) : void  {
+        super.createForEdit(parent, xoff, yoff) ;
+        this.ctrl = document.createElement('div') ;
+        this.ctrl.style.border = '2px dashed #94a3b8' ;
+        this.ctrl.style.borderRadius = '12px' ;
+        this.ctrl.style.background = '#f8fafc' ;
+        this.ctrl.style.display = 'flex' ;
+        this.ctrl.style.alignItems = 'center' ;
+        this.ctrl.style.justifyContent = 'center' ;
+
+        this.status_ = document.createElement('div') ;
+        this.status_.style.padding = '12px' ;
+        this.status_.style.textAlign = 'center' ;
+        this.status_.style.fontSize = '18px' ;
+        this.ctrl.appendChild(this.status_) ;
+        this.updateFromItem(true, 1.0, xoff, yoff) ;
+        parent.appendChild(this.ctrl) ;
+    }
+
+    public createForScouting(parent: HTMLElement, scale: number, xoff: number, yoff:number) : void  {
+        super.createForScouting(parent, scale, xoff, yoff) ;
+
+        this.ctrl = document.createElement('div') ;
+        this.ctrl.style.display = 'flex' ;
+        this.ctrl.style.flexDirection = 'column' ;
+        this.ctrl.style.alignItems = 'stretch' ;
+        this.ctrl.style.justifyContent = 'space-between' ;
+        this.ctrl.style.borderRadius = '12px' ;
+        this.ctrl.style.overflow = 'hidden' ;
+        this.ctrl.style.border = '1px solid #cbd5e1' ;
+        this.ctrl.style.background = '#f8fafc' ;
+
+        this.image_ = document.createElement('img') ;
+        this.image_.style.width = '100%' ;
+        this.image_.style.height = 'calc(100% - 42px)' ;
+        this.image_.style.objectFit = 'contain' ;
+        this.image_.style.background = '#e2e8f0' ;
+        this.ctrl.appendChild(this.image_) ;
+
+        this.status_ = document.createElement('div') ;
+        this.status_.style.fontSize = '14px' ;
+        this.status_.style.padding = '8px 10px' ;
+        this.status_.style.color = '#334155' ;
+        this.ctrl.appendChild(this.status_) ;
+
+        if (this.robotItem.mode === 'capture') {
+            this.button_ = document.createElement('button') ;
+            this.button_.type = 'button' ;
+            this.button_.addEventListener('click', this.choosePhoto.bind(this)) ;
+            this.button_.style.margin = '0 10px 10px 10px' ;
+            this.button_.style.padding = '8px 10px' ;
+            this.button_.style.borderRadius = '8px' ;
+            this.button_.style.border = '1px solid #2563eb' ;
+            this.button_.style.background = '#2563eb' ;
+            this.button_.style.color = 'white' ;
+            this.button_.style.cursor = 'pointer' ;
+            this.ctrl.appendChild(this.button_) ;
+
+            this.input_ = document.createElement('input') ;
+            this.input_.type = 'file' ;
+            this.input_.accept = 'image/*' ;
+            this.input_.setAttribute('capture', 'environment') ;
+            this.input_.style.display = 'none' ;
+            this.input_.addEventListener('change', this.photoSelected.bind(this)) ;
+            this.ctrl.appendChild(this.input_) ;
+        }
+
+        parent.appendChild(this.ctrl) ;
+        this.updateFromItem(false, scale, xoff, yoff) ;
+    }
+
+    private get robotItem() : IPCRobotPhotoItem {
+        return this.item as IPCRobotPhotoItem ;
+    }
+
+    private choosePhoto() : void {
+        this.input_?.click() ;
+    }
+
+    private async photoSelected() {
+        if (!this.input_ || !this.input_.files || this.input_.files.length === 0) {
+            return ;
+        }
+
+        const file = this.input_.files[0] ;
+        const compressed = await this.compressImage(file) ;
+        const context = this.getCaptureContext() ;
+        if (!compressed || !context) {
+            return ;
+        }
+
+        this.current_key_ = `robot-photo-${context.eventUuid}-${context.teamNumber}` ;
+        this.local_data_url_ = compressed.dataUrl ;
+        this.renderState() ;
+
+        const payload : IPCRobotPhotoCaptureRequest = {
+            item: context.item,
+            key: this.current_key_,
+            teamNumber: context.teamNumber,
+            data: compressed.base64,
+            mimeType: 'image/webp',
+            extension: 'webp',
+        } ;
+        this.view.app.request('store-robot-photo', payload) ;
+        this.input_.value = '' ;
+    }
+
+    private async compressImage(file: File) : Promise<{ dataUrl: string, base64: string } | undefined> {
+        const image = await this.loadFileImage(file) ;
+        const canvas = document.createElement('canvas') ;
+        const ctx = canvas.getContext('2d') ;
+        if (!ctx) {
+            return undefined ;
+        }
+
+        const dims = this.fitWithin(image.naturalWidth || image.width, image.naturalHeight || image.height, 1280, 720) ;
+        canvas.width = dims.width ;
+        canvas.height = dims.height ;
+        ctx.drawImage(image, 0, 0, dims.width, dims.height) ;
+        const dataUrl = canvas.toDataURL('image/webp', 0.85) ;
+        const comma = dataUrl.indexOf(',') ;
+        if (comma === -1) {
+            return undefined ;
+        }
+
+        return {
+            dataUrl: dataUrl,
+            base64: dataUrl.substring(comma + 1),
+        } ;
+    }
+
+    private loadFileImage(file: File) : Promise<HTMLImageElement> {
+        return new Promise((resolve, reject) => {
+            const image = new Image() ;
+            image.onload = () => {
+                URL.revokeObjectURL(image.src) ;
+                resolve(image) ;
+            } ;
+            image.onerror = () => {
+                URL.revokeObjectURL(image.src) ;
+                reject(new Error('Failed to load image')) ;
+            } ;
+            image.src = URL.createObjectURL(file) ;
+        }) ;
+    }
+
+    private fitWithin(width: number, height: number, maxLandscapeWidth: number, maxLandscapeHeight: number) : { width: number, height: number } {
+        if (width <= 0 || height <= 0) {
+            return { width: 1, height: 1 } ;
+        }
+
+        let maxWidth = maxLandscapeWidth ;
+        let maxHeight = maxLandscapeHeight ;
+        if (height > width) {
+            maxWidth = maxLandscapeHeight ;
+            maxHeight = maxLandscapeWidth ;
+        }
+
+        const scale = Math.min(maxWidth / width, maxHeight / height, 1.0) ;
+        return {
+            width: Math.max(1, Math.round(width * scale)),
+            height: Math.max(1, Math.round(height * scale)),
+        } ;
+    }
+
+    private renderState() {
+        if (!this.image_ || !this.status_) {
+            return ;
+        }
+
+        if (this.local_data_url_) {
+            this.image_.src = this.local_data_url_ ;
+            this.status_.innerText = 'Robot photo ready' ;
+        }
+        else if (this.current_key_) {
+            this.status_.innerText = 'Robot photo loading...' ;
+        }
+        else if (this.robotItem.mode === 'display') {
+            this.image_.removeAttribute('src') ;
+            this.status_.innerText = 'No robot photo available' ;
+        }
+        else {
+            this.image_.removeAttribute('src') ;
+            this.status_.innerText = 'No robot photo selected' ;
+        }
+
+        if (this.button_) {
+            this.button_.innerText = this.current_key_ ? 'Retake Photo' : 'Take Photo' ;
+        }
+    }
+
+    private loadImageForKey(key: string) {
+        this.image_src_.getImageData(key)
+            .then((data: IPCImageResponse) => {
+                if (data.data && this.image_) {
+                    this.local_data_url_ = this.image_src_.buildDataUrl(data) ;
+                    this.image_.src = this.local_data_url_ ;
+                    if (this.status_) {
+                        this.status_.innerText = 'Robot photo ready' ;
+                    }
+                    if (this.button_) {
+                        this.button_.innerText = 'Retake Photo' ;
+                    }
+                }
+            })
+            .catch(() => {
+                if (this.status_) {
+                    this.status_.innerText = this.robotItem.mode === 'display' ? 'No robot photo available' : 'Unable to load robot photo' ;
+                }
+            }) ;
+    }
+
+    private refreshFromActiveTeamResult() {
+        const result = this.getActiveTeamResult() ;
+        const sourceTag = (this.robotItem.sourceTag || '').trim() ;
+        if (!result || sourceTag.length === 0) {
+            this.current_key_ = undefined ;
+            this.local_data_url_ = undefined ;
+            this.renderState() ;
+            return ;
+        }
+
+        for (const one of result.data) {
+            if (one.tag === sourceTag && one.value.type === 'string' && typeof one.value.value === 'string' && one.value.value.length > 0) {
+                this.current_key_ = one.value.value ;
+                this.local_data_url_ = undefined ;
+                this.loadImageForKey(this.current_key_) ;
+                return ;
+            }
+        }
+
+        this.current_key_ = undefined ;
+        this.local_data_url_ = undefined ;
+        this.renderState() ;
+    }
+
+    private getActiveTeamResult() : IPCScoutResult | undefined {
+        const view = this.view as any ;
+        if (view && typeof view.getActiveTeamResult === 'function') {
+            return view.getActiveTeamResult() ;
+        }
+        return undefined ;
+    }
+
+    private getCaptureContext() : { item: string, teamNumber: number, eventUuid: string } | undefined {
+        const view = this.view as any ;
+        if (!view || typeof view.getScoutItemId !== 'function') {
+            return undefined ;
+        }
+
+        const item = view.getScoutItemId() as string | undefined ;
+        const formInfo = view.getFormInfo ? view.getFormInfo() as IPCFormScoutData | undefined : undefined ;
+        const eventUuid = formInfo?.eventUuid ;
+        if (!item || !eventUuid || !item.startsWith('st-')) {
+            return undefined ;
+        }
+
+        return {
+            item: item,
+            teamNumber: +item.substring(3),
+            eventUuid: eventUuid,
+        } ;
+    }
+}

--- a/renderer/src/views/forms/dialogs/editrobotphotodialog.ts
+++ b/renderer/src/views/forms/dialogs/editrobotphotodialog.ts
@@ -1,0 +1,64 @@
+import { IPCRobotPhotoItem } from "../../../shared/ipc.js";
+import { FormControl } from "../controls/formctrl.js";
+import { EditFormControlDialog } from "./editformctrldialog.js";
+
+export class EditRobotPhotoDialog extends EditFormControlDialog {
+    private mode_? : HTMLSelectElement ;
+    private source_tag_? : HTMLInputElement ;
+
+    constructor(formctrl: FormControl) {
+        super('Edit Robot Photo', formctrl) ;
+    }
+
+    protected async populateDialog(pdiv: HTMLElement) : Promise<void> {
+        const item = this.formctrl_.item as IPCRobotPhotoItem ;
+        const div = document.createElement('div') ;
+        div.className = 'xero-popup-form-edit-dialog-rowdiv' ;
+
+        this.populateTag(div) ;
+
+        this.mode_ = document.createElement('select') ;
+        this.mode_.className = 'xero-popup-form-edit-dialog-select' ;
+        let option = document.createElement('option') ;
+        option.value = 'capture' ;
+        option.innerText = 'Capture (team form)' ;
+        this.mode_.appendChild(option) ;
+        option = document.createElement('option') ;
+        option.value = 'display' ;
+        option.innerText = 'Display (match form)' ;
+        this.mode_.appendChild(option) ;
+        this.mode_.value = item.mode ;
+
+        let label = document.createElement('label') ;
+        label.className = 'xero-popup-form-edit-dialog-label' ;
+        label.innerText = 'Mode' ;
+        label.appendChild(this.mode_) ;
+        div.appendChild(label) ;
+
+        this.source_tag_ = document.createElement('input') ;
+        this.source_tag_.type = 'text' ;
+        this.source_tag_.className = 'xero-popup-form-edit-dialog-input' ;
+        this.source_tag_.value = item.sourceTag || '' ;
+        label = document.createElement('label') ;
+        label.className = 'xero-popup-form-edit-dialog-label' ;
+        label.innerText = 'Source Tag' ;
+        label.appendChild(this.source_tag_) ;
+        div.appendChild(label) ;
+
+        pdiv.appendChild(div) ;
+    }
+
+    protected extractData(): void {
+        const item = this.formctrl_.item as IPCRobotPhotoItem ;
+        item.tag = this.tag_!.value ;
+        item.mode = this.mode_!.value as 'capture' | 'display' ;
+        item.sourceTag = this.source_tag_!.value.trim() ;
+        item.datatype = 'string' ;
+    }
+
+    public onInit() {
+        setTimeout(() => {
+            this.tag_?.focus() ;
+        }, 100) ;
+    }
+}

--- a/renderer/src/views/forms/editformview.ts
+++ b/renderer/src/views/forms/editformview.ts
@@ -25,6 +25,7 @@ import { KeybindingManager } from "./keybindings.js";
 import { KeybindingDialog } from "./dialogs/keybindingdialog.js";
 import { TextAreaControl } from "./controls/textareactrl.js";
 import { ImageControl } from "./controls/imagectrl.js";
+import { RobotPhotoControl } from "./controls/robotphotoctrl.js";
 import { UndoDeleteControlArgs, UndoDeleteSectionArgs, UndoEditArgs, UndoLockContorlArgs, UndoMoveResizeArgs, UndoMoveSectionArgs, UndoRenameSectionArgs, UndoStackEntry } from "./undo.js";
 import { RulesEngine } from "../../shared/rulesengine.js";
 import { IPCFormItem, IPCSection, IPCTablet } from "../../shared/ipc.js";
@@ -129,6 +130,7 @@ export class XeroEditFormView extends XeroView {
             new XeroPopupMenuItem('Label', this.addNewLabelCtrl.bind(this)),
             new XeroPopupMenuItem('Box', this.addNewBoxCtrl.bind(this)),
             new XeroPopupMenuItem('Image', this.addNewImageCtrl.bind(this)),
+            new XeroPopupMenuItem('Robot Photo', this.addNewRobotPhotoCtrl.bind(this)),
             new XeroPopupMenuItem('Text Field', this.addNewTextCtrl.bind(this)),
             new XeroPopupMenuItem('Text Area', this.addNewTextAreaCtrl.bind(this)),
             new XeroPopupMenuItem('Up/Down Field', this.addNewUpDownCtrl.bind(this)),
@@ -322,6 +324,7 @@ export class XeroEditFormView extends XeroView {
         this.keybindings_.addKeybinding('F10', false, false, false, 'Insert a new timer control', this.addNewTimerCtrl.bind(this));
         this.keybindings_.addKeybinding('F11', false, false, false, 'Insert a new image control', this.addNewImageCtrl.bind(this));
         this.keybindings_.addKeybinding('F12', false, false, false, 'Insert a new stopwatch control', this.addNewStopwatchCtrl.bind(this));
+        this.keybindings_.addKeybinding('F12', true, false, false, 'Insert a new robot photo control', this.addNewRobotPhotoCtrl.bind(this));
     }
 
     private showErrors() {
@@ -429,6 +432,18 @@ export class XeroEditFormView extends XeroView {
             alert('You cannot create a image control without a section. Use the "Section" menu to add a section first.') ;
         }
     }    
+
+    private addNewRobotPhotoCtrl() {
+        if (this.tabbed_ctrl_?.selectedPageNumber !== -1) {
+            let formctrl = new RobotPhotoControl(this.app.imageSource!, this, this.getUniqueTagName(), XeroRect.fromPointSize(this.context_menu_cursor_, new XeroSize(280, 220))) ;
+            this.addItemToCurrentSection(formctrl.item) ;
+            this.section_pages_[this.tabbed_ctrl_!.selectedPageNumber].addControl(formctrl) ;
+            this.modified(new UndoStackEntry('add', 'control', [formctrl])) ;
+        }
+        else {
+            alert('You cannot create a robot photo control without a section. Use the "Section" menu to add a section first.') ;
+        }
+    }
 
     private addNewBoxCtrl() {
         if (this.tabbed_ctrl_?.selectedPageNumber !== -1) {
@@ -625,6 +640,10 @@ export class XeroEditFormView extends XeroView {
         else if (item.type === 'image') {
             let imagectrl = new ImageControl(this.app.imageSource!, this, item.tag, new XeroRect(item.x, item.y, item.width, item.height)) ;
             formctrl = imagectrl ;
+            formctrl.update(item) ;
+        }
+        else if (item.type === 'robotphoto') {
+            formctrl = new RobotPhotoControl(this.app.imageSource!, this, item.tag, new XeroRect(item.x, item.y, item.width, item.height)) ;
             formctrl.update(item) ;
         }
         else if (item.type === 'box') {

--- a/renderer/src/views/forms/scoutformview.ts
+++ b/renderer/src/views/forms/scoutformview.ts
@@ -18,6 +18,7 @@ import { StopwatchControl } from "./controls/stopwatchctrl.js";
 import {  TimerControl  } from "./controls/timerctrl.js";
 import { AutoPlanControl } from "./controls/autoplanctrl.js";
 import { AutoSelectorControl } from "./controls/autoselectorctrl.js";
+import { RobotPhotoControl } from "./controls/robotphotoctrl.js";
 import {  UpDownControl  } from "./controls/updownctrl.js";
 import { XeroFormDataValues } from "./formdatavalues.js";
 import {  FormObject  } from "./formobj.js";
@@ -107,6 +108,10 @@ export class XeroScoutFormView extends XeroView {
 
     public getScoutItemId(): string | undefined {
         return this.form_info_?.scoutItem ;
+    }
+
+    public getFormInfo(): IPCFormScoutData | undefined {
+        return this.form_info_ ;
     }
 
     private isCentralMatchPreview() : boolean {
@@ -444,6 +449,10 @@ export class XeroScoutFormView extends XeroView {
                 }
                 else if (item.type === 'autoselector') {
                     formctrl = new AutoSelectorControl(this.app.imageSource!, this, item.tag, new XeroRect(item.x, item.y, item.width, item.height)) ;
+                    formctrl.update(item) ;
+                }
+                else if (item.type === 'robotphoto') {
+                    formctrl = new RobotPhotoControl(this.app.imageSource!, this, item.tag, new XeroRect(item.x, item.y, item.width, item.height)) ;
                     formctrl.update(item) ;
                 }
                 else {

--- a/renderer/src/widgets/xeropopupmenu.ts
+++ b/renderer/src/widgets/xeropopupmenu.ts
@@ -66,6 +66,7 @@ export class XeroPopupMenuItem {
 
 export class XeroPopupMenu extends EventEmitter {
     private static MenuItemTopDivClassName = 'xero-popup-menu-item-div' ;
+    private static MaxVisibleItems = 6 ;
 
     //
     // There can only be one menu open at a time, so we use a static variable to track the current menu
@@ -312,6 +313,18 @@ export class XeroPopupMenu extends EventEmitter {
         }
 
         this.parent_.appendChild(this.popup_) ; 
+
+        if (this.items_.length > XeroPopupMenu.MaxVisibleItems) {
+            const firstItem = this.items_[0].topdiv ;
+            if (firstItem) {
+                const itemHeight = firstItem.getBoundingClientRect().height ;
+                if (itemHeight > 0) {
+                    this.popup_.style.maxHeight = `${itemHeight * XeroPopupMenu.MaxVisibleItems}px` ;
+                    this.popup_.style.overflowY = 'auto' ;
+                    this.popup_.style.overflowX = 'hidden' ;
+                }
+            }
+        }
 
         if (!child) {
             XeroPopupMenu.top_most_menu_ = this ;


### PR DESCRIPTION
  - add team robot photo capture, WebP compression, storage, and sync to Central/match scouting
  - support one-time missing-image photo distribution and robot photo display in match forms
  - cap long form editor popup menus to six visible items and enable scrolling