### PR TITLE
Harden Scout/Central Sync Data Integrity and Fix Renderer State Duplication

### DIFF
--- a/main/content/css/form.css
+++ b/main/content/css/form.css
@@ -60,6 +60,30 @@
     cursor: pointer;
 }
 
+.xero-form-header-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.xero-form-reset-match-button {
+    font-family: Arial;
+    font-size: 16px;
+    font-weight: 600;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid #666;
+    background: #fff;
+    color: #222;
+    cursor: pointer;
+    margin-right: 10px;
+}
+
+.xero-form-reset-match-button:hover {
+    background: #f4f4f4;
+}
+
 .xero-form-tab {
     border: 1px solid #ccc;
     background-color:   rgb(192, 192, 192) ;

--- a/main/docs/database-sync-deep-dive.md
+++ b/main/docs/database-sync-deep-dive.md
@@ -560,6 +560,83 @@ flowchart TD
     REQPLAYASSIGN --> PROVPLAYASSIGN --> REQPLAYSTATUS --> PROVPLAYSTATUS --> READY --> UPLOAD --> INGEST --> ACK --> BYE --> DONE
 ```
 
+### 8.7 Mermaid: scouting sync sequence
+
+This sequence view is useful when debugging sync stability because it shows the strict packet ordering and where the scout waits for the next response.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant S as Scout Tablet
+    participant C as Central
+    participant DB as team.db / match.db
+    participant EJ as event.json / image store
+
+    U->>S: Click Sync
+    S->>S: Save current in-memory form state into local results_
+    S->>C: HelloFromScouter
+    C->>C: Validate locked event, UUID, and sync availability
+    alt Central rejects sync
+        C-->>S: Error
+    else Central accepts sync
+        C-->>S: HelloFromScouter(event uuid, event name)
+        opt Tablet identity missing
+            S->>C: RequestTablets
+            C-->>S: ProvideTablets
+            U->>S: Choose tablet and purpose
+            S->>S: Persist tablet assignment locally
+        end
+
+        S->>C: RequestTeamForm
+        C-->>S: ProvideTeamForm
+        Note over S,C: Example payload: team.json form definition
+
+        S->>C: RequestMatchForm
+        C-->>S: ProvideMatchForm
+        Note over S,C: Example payload: match.json form definition
+
+        S->>C: RequestMatchList
+        C-->>S: ProvideMatchList
+        Note over S,C: Example payload: qm1 / red1 / frc254 assignment
+
+        S->>C: RequestTeamList
+        C-->>S: ProvideTeamList
+        Note over S,C: Example payload: st-254 and st-1678 assignments
+
+        opt Missing match scouting results
+            S->>C: RequestMatchResults(sm-qm-1-12-254)
+            C->>EJ: Read cached match_results_
+            C-->>S: ProvideMatchResults
+        end
+
+        opt Missing team scouting results
+            S->>C: RequestTeamResults(st-254)
+            C->>EJ: Read cached team_results_
+            C-->>S: ProvideTeamResults
+        end
+
+        opt Missing robot photos or other form images
+            S->>C: RequestImages(frc254-front, robot-side)
+            C->>EJ: Read image files and base64 encode
+            C-->>S: ProvideImages
+        end
+
+        S->>C: RequestPlayoffAssignments
+        C-->>S: ProvidePlayoffAssignments
+        S->>C: RequestPlayoffStatus
+        C-->>S: ProvidePlayoffStatus
+
+        S->>S: Refresh UI and finalize local synced state
+        S->>C: ProvideResults(full local results_ array)
+        Note over S,C: Example items: st-254 and sm-qm-1-12-254
+        C->>DB: Upsert relational rows by natural key
+        C->>EJ: Replace raw cached IPCScoutResult by item
+        C-->>S: ReceivedResults
+        S->>C: GoodbyeFromScouter
+    end
+```
+
 ## 9. How Scout Decides What To Download
 
 ### 9.1 Match results

--- a/main/docs/database-sync-deep-dive.md
+++ b/main/docs/database-sync-deep-dive.md
@@ -1,0 +1,1175 @@
+# Database Structure And Sync Deep Dive
+
+This document describes how XeroScout currently stores event data, how sync is initiated, the exact packet flow used during sync, and what gets merged, overwritten, or left alone.
+
+It is based on the current implementation in:
+
+- `main/src/main/project/`
+- `main/src/main/model/`
+- `main/src/main/apps/scscout.ts`
+- `main/src/main/apps/sccentral.ts`
+- `main/src/main/apps/sccoach.ts`
+- `main/src/main/sync/`
+
+## Reading Guide
+
+If you are trying to understand the system from the code outward, these are the most important files to read first:
+
+- `main/src/main/project/project.ts`: project lifecycle, lock flow, and manager wiring
+- `main/src/main/project/datamgr.ts`: the bridge between sync payloads and the SQLite models
+- `main/src/main/model/datamodel.ts`: dynamic schema creation and insert-or-update behavior
+- `main/src/main/apps/scscout.ts`: scout-side handshake, missing-data download, and upload
+- `main/src/main/apps/sccentral.ts`: central-side packet handlers and authoritative sync responses
+- `main/src/main/apps/sccoach.ts`: coach-side full-project sync behavior
+- `main/src/main/sync/syncbase.ts`: packet framing, checksum, and packet extraction
+
+## Component Map
+
+This is the shortest useful mental map of the implementation.
+
+### Storage and project state
+
+- `Project`
+  - owns the event directory and all managers
+  - creates/opens the event
+  - locks the event and initializes the databases
+- `ProjectInfo`
+  - JSON-serializable metadata persisted in `event.json`
+- `DataManager`
+  - routes result payloads into either the team or match database
+  - maintains the raw sync-result caches kept in `event.json`
+- `FormManager`
+  - owns form file paths
+  - validates forms
+  - extracts form-defined DB columns
+- `ImageManager`
+  - owns the local image cache
+  - syncs images as base64 payloads
+
+### SQLite layer
+
+- `DataModel`
+  - shared base class for SQLite access, column creation, and upsert logic
+- `TeamDataModel`
+  - team table schema and team result ingestion
+- `MatchDataModel`
+  - match table schema and match result ingestion
+- `DataRecord`
+  - in-memory typed row container used during insert/update flows
+
+### Sync transport and protocol
+
+- `SyncBase`
+  - packet framing, buffering, checksum, and packet extraction
+- `TCPClient`
+  - scout/coach TCP client transport
+- `TCPSyncServer`
+  - central TCP server transport
+- `PacketObj`
+  - packet type plus payload bytes
+- `PacketType`
+  - protocol enum
+
+### App roles
+
+- `SCCentral`
+  - authoritative packet handler implementation
+- `SCScout`
+  - missing-data downloader and scouting-result uploader
+- `SCCoach`
+  - full-project replica downloader plus coach-config uploader
+
+## 1. High-Level Architecture
+
+There are three relevant app roles:
+
+- `central`: the authoritative event host
+- `scout`: the tablet used to collect team or match scouting data
+- `coach`: a read-mostly consumer that syncs a local copy of the entire project databases, plus pushes its own coach-owned graph/picklist config back to central
+
+The system persists data in two different forms:
+
+- JSON files for project metadata, configuration, schedules, and cached scouting payloads
+- SQLite databases for the team and match datasets used by central and coach
+
+At a high level:
+
+- `central` owns the canonical event definition and canonical SQLite databases
+- `scout` does not maintain SQLite databases; it stores synced metadata and unsent/already-sent scouting results in a JSON file keyed by event UUID
+- `coach` receives a full copy of `event.json`, `team.db`, and `match.db`, and then opens those locally as a normal project
+
+## 2. Where Data Lives
+
+### 2.1 Central event storage
+
+A central event lives in an event directory chosen by the user. That directory contains at least:
+
+- `event.json`
+- `team.db`
+- `match.db`
+- copied form files such as `team.json` and `match.json`
+
+`event.json` is the main project metadata file. It contains:
+
+- event identity and lock state
+- Blue Alliance or manual event setup information
+- tablet definitions and generated assignments
+- formulas, datasets, picklists, graphs, playoff state
+- column metadata for both SQLite databases
+- cached synced scouting result payloads in `data_info_`
+
+`team.db` and `match.db` are created when the event is locked.
+
+### 2.2 Scout local storage
+
+The scout app stores its local state under the app directory:
+
+- `~/.xeroscout/`
+
+The active event state is stored as a JSON file whose filename is the event UUID. The app also stores a setting pointing to the last synced event UUID so it can reopen that state on launch.
+
+The scout-side JSON contains:
+
+- tablet identity
+- tablet purpose (`team` or `match`)
+- event UUID and event name
+- synced forms
+- synced team and match assignments
+- local scouting results for assigned items
+- cached team results used by match scouting screens
+- synced playoff assignments and playoff status
+
+The scout app also stores synced images under the user-data image cache managed by `ImageManager`.
+
+Important: the scout app is not backed by `team.db` or `match.db`. Its local persistent state is JSON plus cached images.
+
+### 2.3 Coach local storage
+
+The coach app stores synced projects under:
+
+- `~/.xeroscout/projects/<event-uuid>/`
+
+During sync, central sends:
+
+- `event.json`
+- `team.db`
+- `match.db`
+- `team.json`
+- `match.json`
+- any missing form images
+
+The coach app writes those files locally, then opens the synced project directory as a normal project.
+
+## 3. Database Structure
+
+### 3.1 SQLite databases
+
+There are exactly two SQLite databases:
+
+- `team.db`, containing table `teams`
+- `match.db`, containing table `matches`
+
+These are managed by:
+
+- `TeamDataModel`
+- `MatchDataModel`
+- shared base class `DataModel`
+
+### 3.2 Base table keys
+
+The `teams` table starts with these base columns:
+
+- `key` (`TEXT`)
+- `team_number` (`INTEGER`)
+
+The practical merge key used for team upserts is:
+
+- `team_number`
+
+The `matches` table starts with these base columns:
+
+- `key` (`TEXT`)
+- `comp_level` (`TEXT`)
+- `set_number` (`REAL` in the SQL definition, but used as integer semantics)
+- `match_number` (`REAL` in the SQL definition, but used as integer semantics)
+- `team_key` (`TEXT`)
+
+The practical merge key used for match upserts is:
+
+- `comp_level`
+- `set_number`
+- `match_number`
+- `team_key`
+
+Each logical FRC match becomes six rows in `match.db`, one per team/alliance slot.
+
+### 3.3 Dynamic columns
+
+Most columns are not hardcoded. They are added dynamically with `ALTER TABLE ... ADD COLUMN ...` when data arrives.
+
+Column definitions are tracked in `ProjectInfo` through:
+
+- `team_db_info_.col_descs_`
+- `match_db_info_.col_descs_`
+
+Each `IPCColumnDesc` records:
+
+- column name
+- value type
+- source
+- whether the column is editable
+
+Column `source` is one of:
+
+- `base`
+- `form`
+- `bluealliance`
+- `statbotics`
+
+### 3.4 How form fields become DB columns
+
+When the event is locked:
+
+1. `DataManager.init()` opens or creates `team.db` and `match.db`
+2. Blue Alliance team data is inserted into `team.db`
+3. Blue Alliance match schedule is inserted into `match.db`
+4. `FormManager.populateDBWithForms()` removes old form-sourced columns
+5. The current team and match form data-bearing controls are converted into `IPCColumnDesc[]`
+6. Those columns are created in the SQLite tables
+
+This means the schema is partly form-defined. Changing forms and re-locking can change the schema.
+
+Important detail:
+
+- old `form` columns are removed before new form columns are added
+- non-form columns from `base`, `bluealliance`, and `statbotics` remain
+
+### 3.5 Typed values and SQLite storage
+
+The app uses `IPCTypedDataValue` in memory, then converts those to SQLite-compatible primitives before writing:
+
+- `string` -> text
+- `integer` -> integer
+- `real` -> real
+- `boolean` -> integer/boolean-compatible SQLite value
+- `null` -> null
+
+Array and error values are not stored directly in SQLite.
+
+### 3.6 Key database classes and methods
+
+The storage behavior is concentrated in a small number of methods.
+
+- `DataModel.addColsAndData()`
+  - computes any missing columns from incoming records
+  - creates those columns if necessary
+  - writes each record via `insertOrUpdate()`
+- `DataModel.insertOrUpdate()`
+  - checks whether a row already exists for the natural key
+  - updates the row if it exists
+  - inserts a new row otherwise
+- `DataModel.updateRecord()`
+  - updates only the fields present in the incoming `DataRecord`
+- `FormManager.populateDBWithForms()`
+  - removes old form-sourced columns
+  - recreates columns from the current team and match forms
+- `DataManager.processResults()`
+  - dispatches synced results to the correct model
+  - merges the raw result cache stored in `event.json`
+
+### 3.7 Focused snippet: row upsert behavior
+
+This is the core write path in `DataModel`. It is the reason sync behaves as “upsert by natural key” rather than append-only.
+
+```ts
+public async insertOrUpdate(table: string, keys: string[], dr: DataRecord) : Promise<void> {
+    let results = this.generateWhereClause(keys, dr) ;
+    let query: string = 'select * from ' + table + results[0] + ';' ;
+    let rows = await this.all(query, results[1]) ;
+    if (rows.length > 0) {
+        await this.updateRecord(table, keys, dr)
+    }
+    else {
+        await this.insertRecord(table, dr) ;
+    }
+}
+```
+
+Implications:
+
+- the key columns define row identity
+- repeated syncs for the same logical item target the same row
+- updates are partial at the column level because `updateRecord()` only writes fields present in the incoming record
+
+## 4. What `event.json` Stores For Data
+
+Central uses `DataInfo` inside `event.json` to store metadata around the databases and sync:
+
+- team DB column config for UI
+- match DB column config for UI
+- `scouted_team_`: list of team numbers that have scouting data
+- `scouted_match_`: list of scouted match item IDs
+- `team_results_`: latest raw synced team scouting payloads by `item`
+- `match_results_`: latest raw synced match scouting payloads by `item`
+- team/match DB formatting formulas
+
+This matters because central does not only persist processed row values in SQLite. It also keeps the latest raw scouting payloads in `event.json`, and those payloads are what get sent back to scouts when they request missing results.
+
+## 5. Sync Transport And Packet Format
+
+Sync is implemented over TCP. Central runs `TCPSyncServer`, while scout and coach use `TCPClient`.
+
+The packet header format is:
+
+- 4 bytes: packet type
+- 4 bytes: payload length
+- 2 bytes: compression type
+- N bytes: payload
+- 2 bytes: checksum
+
+Current behavior:
+
+- compression is always `PacketCompressionNone`
+- checksum is a simple 16-bit additive checksum over the payload
+
+Packet types are defined in `main/src/main/sync/packettypes.ts`.
+
+### 5.1 Focused snippet: packet framing
+
+The protocol is not HTTP or JSON-over-lines. It is a custom framed binary envelope carrying JSON or raw DB bytes.
+
+```ts
+buffer[0] = (p.type_ >> 0) & 0xff ;
+buffer[4] = (p.data_.length >> 0) & 0xff ;
+buffer[8] = (comp >> 0) & 0xff ;
+buffer.set(p.data_, 10) ;
+
+let csum = this.computeSum16(p.data_, 0, p.data_.length) ;
+buffer[p.data_.length + 10] = (csum >> 0) & 0xff;
+buffer[p.data_.length + 11] = (csum >> 8) & 0xff ;
+```
+
+That framing lives in `SyncBase.convertToBytes()` and is decoded in `SyncBase.extractPacket()`.
+
+## 6. When Sync Server Starts
+
+Central starts the sync server when a locked event is opened or created. It also starts UDP broadcast for discovery/advertising.
+
+Central maintains two guard flags around sync:
+
+- `tablets_syncing_`
+- `external_download_in_progress_`
+
+Behavior:
+
+- external data downloads are blocked while tablets are syncing
+- scout sync is rejected while central is in the middle of an external download
+
+## 7. Scout Sync Initiation
+
+Scout sync can be initiated from the menu using:
+
+- local `127.0.0.1`
+- cable `192.168.1.1`
+- WiFi or manual address flow
+
+Before any sync connection attempt:
+
+- the scout app asks the renderer for current in-progress form results
+- those results are written into the scout’s local JSON cache
+
+That means sync always pushes the latest in-memory form state it can collect before connecting.
+
+### 7.1 Key scout-side methods
+
+If you are stepping through scout sync in a debugger, start here:
+
+- `SCScout.syncClient()`
+  - opens the connection, sends the initial hello, and installs packet handlers
+- `SCScout.syncTablet()`
+  - handles every incoming packet from central
+- `SCScout.getMissingData()`
+  - the finite-state “what do I still need?” driver
+- `SCScout.sendScoutingData()`
+  - sends the final `ProvideResults` payload after download is complete
+
+### 7.2 Focused snippet: scout-side sync driver
+
+`getMissingData()` is the clearest expression of the scouter sync state machine.
+
+```ts
+if (!this.team_form_received_) {
+    this.conn_?.send(new PacketObj(PacketType.RequestTeamForm)) ;
+}
+else if (!this.match_form_received_) {
+    this.conn_?.send(new PacketObj(PacketType.RequestMatchForm)) ;
+}
+else if (!this.match_list_received_) {
+    this.conn_?.send(new PacketObj(PacketType.RequestMatchList)) ;
+}
+else if (!this.team_list_received_) {
+    this.conn_?.send(new PacketObj(PacketType.RequestTeamList)) ;
+}
+else if (!this.match_results_received_ && this.needMatchResults().length > 0) {
+    this.conn_?.send(new PacketObj(PacketType.RequestMatchResults, ...)) ;
+}
+```
+
+This method is important because it encodes:
+
+- the order of requests
+- the fact that scout waits for each response before advancing
+- the fact that sync completes only when there is nothing left to request
+
+## 8. Full Scout Sync Sequence
+
+This is the scouter-to-central sync flow.
+
+### 8.1 Handshake
+
+1. Scout connects to central over TCP.
+2. Scout sends `HelloFromScouter`.
+3. If the scout already has a tablet identity, the hello payload includes:
+   - tablet name
+   - purpose
+4. Central replies with `HelloFromScouter` containing:
+   - event UUID
+   - event name
+
+Guardrails:
+
+- if central is busy with external downloads, it responds with `Error`
+- if the scout already has an event UUID and the UUID does not match central’s UUID, scout aborts and tells the user to reset the tablet
+
+### 8.2 New tablet initialization path
+
+If the scout does not yet know its tablet identity:
+
+1. Scout requests `RequestTablets`
+2. Central replies `ProvideTablets` with all unassigned tablets
+3. User chooses a tablet and purpose
+4. Scout persists that assignment locally
+5. Scout starts the normal missing-data fetch pipeline
+
+Central marks this sync session type as `"initialize"` when serving the tablet list.
+
+### 8.3 Missing-data fetch pipeline
+
+Once handshake and tablet assignment are handled, scout fetches data in this fixed order:
+
+1. `RequestTeamForm`
+2. `RequestMatchForm`
+3. `RequestMatchList`
+4. `RequestTeamList`
+5. `RequestMatchResults` if needed
+6. `RequestTeamResults` if needed
+7. `RequestImages` if needed
+8. `RequestPlayoffAssignments` if not already known
+9. `RequestPlayoffStatus`
+
+The scout only moves to the next step once the previous response has been received and processed.
+
+### 8.4 What each response does on scout
+
+- `ProvideTeamForm`
+  - stores the team form JSON locally
+- `ProvideMatchForm`
+  - stores the match form JSON locally
+- `ProvideMatchList`
+  - stores match-to-tablet assignments locally
+- `ProvideTeamList`
+  - stores team-to-tablet assignments locally
+- `ProvideMatchResults`
+  - fills in missing match result payloads
+- `ProvideTeamResults`
+  - fills in missing team result payloads and updates the local team-results cache
+- `ProvideImages`
+  - writes missing images into the scout image cache
+- `ProvidePlayoffAssignments`
+  - stores playoff tablet assignments if any
+- `ProvidePlayoffStatus`
+  - stores current playoff bracket/outcome state if any
+
+### 8.5 Completion
+
+When scout determines there is no more missing data:
+
+1. it updates navigation/UI using the synced data
+2. it sends `ProvideResults` containing all locally stored scouting results for that tablet
+3. central processes those results
+4. central replies `ReceivedResults`
+5. scout sends `GoodbyeFromScouter`
+6. central shows a sync-complete message and clears `tablets_syncing_`
+
+### 8.6 Mermaid: scout sync end-to-end
+
+This flowchart shows the actual scout sync order, including the points where different data types move.
+
+```mermaid
+flowchart TD
+    START[Scout user clicks Sync]
+    SAVE[Scout saves in-memory form state to local JSON results_]
+    CONNECT[Scout opens TCP connection to central]
+    HELLO[Scout sends HelloFromScouter]
+    CHECK{Central accepts sync?}
+    ERR[Central sends Error<br/>Examples: event mismatch, external download in progress]
+    UUID{Scout already has tablet identity?}
+    REQTABS[Scout sends RequestTablets]
+    PROVTABS[Central sends ProvideTablets<br/>Example: tablet names and purposes]
+    ASSIGN[User selects tablet and purpose]
+    TEAMFORM[Scout sends RequestTeamForm]
+    TEAMFORMRESP[Central sends ProvideTeamForm<br/>Example: team.json with image/autoplan/autoselector controls]
+    MATCHFORM[Scout sends RequestMatchForm]
+    MATCHFORMRESP[Central sends ProvideMatchForm<br/>Example: match.json with match scouting fields]
+    MATCHLIST[Scout sends RequestMatchList]
+    MATCHLISTRESP[Central sends ProvideMatchList<br/>Example: qm1 red1 frc254 assigned to tablet]
+    TEAMLIST[Scout sends RequestTeamList]
+    TEAMLISTRESP[Central sends ProvideTeamList<br/>Example: frc254, frc1678 team assignments]
+    NEEDMATCH{Missing match results?}
+    REQMATCHRES[Scout sends RequestMatchResults<br/>Example request ids: sm-qm-1-12-254]
+    PROVMATCHRES[Central sends ProvideMatchResults<br/>Example payload: item sm-qm-1-12-254]
+    NEEDTEAM{Missing team results?}
+    REQTEAMRES[Scout sends RequestTeamResults<br/>Example request ids: st-254]
+    PROVTEAMRES[Central sends ProvideTeamResults<br/>Example payload: item st-254]
+    NEEDIMAGES{Missing form images?}
+    REQIMAGES[Scout sends RequestImages<br/>Example names: frc254-front, robot-side, missing]
+    PROVIMAGES[Central sends ProvideImages<br/>Example robot photo base64 plus mimeType and extension]
+    REQPLAYASSIGN[Scout sends RequestPlayoffAssignments]
+    PROVPLAYASSIGN[Central sends ProvidePlayoffAssignments<br/>Example: finals tablet reassignment]
+    REQPLAYSTATUS[Scout sends RequestPlayoffStatus]
+    PROVPLAYSTATUS[Central sends ProvidePlayoffStatus<br/>Example: bracket advancement state]
+    READY[Scout has all required remote data]
+    UPLOAD[Scout sends ProvideResults<br/>Examples: st-254 and sm-qm-1-12-254]
+    INGEST[Central upserts SQLite rows and replaces raw cached items in event.json]
+    ACK[Central sends ReceivedResults]
+    BYE[Scout sends GoodbyeFromScouter]
+    DONE[Sync complete]
+
+    START --> SAVE --> CONNECT --> HELLO --> CHECK
+    CHECK -->|No| ERR
+    CHECK -->|Yes| UUID
+    UUID -->|No| REQTABS --> PROVTABS --> ASSIGN --> TEAMFORM
+    UUID -->|Yes| TEAMFORM
+    TEAMFORM --> TEAMFORMRESP --> MATCHFORM --> MATCHFORMRESP --> MATCHLIST --> MATCHLISTRESP --> TEAMLIST --> TEAMLISTRESP --> NEEDMATCH
+    NEEDMATCH -->|Yes| REQMATCHRES --> PROVMATCHRES --> NEEDTEAM
+    NEEDMATCH -->|No| NEEDTEAM
+    NEEDTEAM -->|Yes| REQTEAMRES --> PROVTEAMRES --> NEEDIMAGES
+    NEEDTEAM -->|No| NEEDIMAGES
+    NEEDIMAGES -->|Yes| REQIMAGES --> PROVIMAGES --> REQPLAYASSIGN
+    NEEDIMAGES -->|No| REQPLAYASSIGN
+    REQPLAYASSIGN --> PROVPLAYASSIGN --> REQPLAYSTATUS --> PROVPLAYSTATUS --> READY --> UPLOAD --> INGEST --> ACK --> BYE --> DONE
+```
+
+## 9. How Scout Decides What To Download
+
+### 9.1 Match results
+
+Scout computes the full list of match items assigned to its tablet and asks central only for the ones it does not already have in local `results_`.
+
+Match item IDs look like:
+
+- `sm-<comp_level>-<set_number>-<match_number>-<teamnumber>`
+
+### 9.2 Team results
+
+Behavior depends on tablet purpose.
+
+For a team tablet:
+
+- it asks only for team result items it does not already have cached locally
+
+For a match tablet:
+
+- it asks for all team scouting items from the team assignment list
+
+That is intentional. Match scouting views can consume team scouting data as context, so match tablets pull the team results cache more broadly.
+
+### 9.3 Images
+
+Scout scans both synced forms for image-bearing controls:
+
+- `image`
+- `autoplan`
+- `autoselector`
+
+It extracts the referenced image names, compares them with the local image cache, and requests only missing ones.
+
+## 10. What Central Sends Back During Scout Sync
+
+Central serves scout sync from two places:
+
+- the project metadata in `event.json`
+- the canonical SQLite-backed project plus raw cached result payloads
+
+Specifically:
+
+- forms are sent from the stored form JSON files
+- match/team assignments are sent from `TabletManager`
+- playoff data is sent from `TabletManager` and `PlayoffManager`
+- images are read from `ImageManager`
+- match/team result payloads are read from `DataInfo.match_results_` and `DataInfo.team_results_`
+
+Important: central does not reconstruct scout payloads from SQLite rows when serving `ProvideMatchResults` or `ProvideTeamResults`. It returns the raw cached `IPCScoutResult` objects stored in `event.json`.
+
+### 10.1 Key central packet handlers
+
+The central sync protocol is almost entirely implemented as packet handlers in `SCCentral`.
+
+- `handleRequestHelloFromScouter()`
+- `handleRequestTablets()`
+- `handleRequestTeamForm()`
+- `handleRequestMatchForm()`
+- `handleRequestTeamList()`
+- `handleRequestMatchList()`
+- `handleRequestTeamResults()`
+- `handleRequestMatchResults()`
+- `handleRequestRequestImages()`
+- `handleProvideResults()`
+
+### 10.2 Focused snippet: central result ingestion
+
+This is the single most important central-side sync call.
+
+```ts
+let obj : IPCScoutResults = JSON.parse(p.payloadAsString()) as IPCScoutResults ;
+const count = await this.project!.data_mgr_!.processResults(obj) ;
+return new PacketObj(PacketType.ReceivedResults);
+```
+
+Everything meaningful after scout upload happens below `DataManager.processResults()`.
+
+## 11. How Up-Sync From Scout Works
+
+Scout always sends:
+
+- tablet name
+- tablet purpose
+- the full local `results_` array
+
+It is not a delta protocol. There is no “send only changed items since last sync” logic.
+
+### 11.1 Result object shape
+
+Each result item is:
+
+- `item`: the logical scouting target ID
+- `data`: array of `{ tag, value }`
+
+Examples:
+
+- team: `st-254`
+- match: `sm-qm-1-12-254`
+
+### 11.2 Central processing path
+
+When central receives `ProvideResults`:
+
+1. it parses the JSON payload into `IPCScoutResults`
+2. it calls `DataManager.processResults(obj)`
+3. `DataManager` dispatches to:
+   - `TeamDataModel.processScoutingResults()` for team data
+   - `MatchDataModel.processScoutingResults()` for match data
+4. those methods convert each result into a `DataRecord`
+5. `DataModel.addColsAndData()` ensures any missing form columns exist
+6. `DataModel.insertOrUpdate()` writes each row by natural key
+7. `DataManager.mergeResults()` updates the cached raw result arrays in `event.json`
+8. `DataManager` updates `scouted_team_` or `scouted_match_`
+9. `event.json` is rewritten
+
+### 11.3 Focused snippet: raw result cache merge
+
+Central’s raw cache merge is not fieldwise. It is itemwise replacement.
+
+```ts
+private mergeResults(target: IPCScoutResult[], incoming: IPCScoutResult[]) {
+    for (let res of incoming) {
+        let index = target.findIndex((one) => one.item === res.item) ;
+        if (index !== -1) {
+            target[index] = res ;
+        }
+        else {
+            target.push(res) ;
+        }
+    }
+}
+```
+
+That means the canonical raw payload for a logical scouting item is always the latest full payload central saw for that `item`.
+
+## 12. Actual Overwrite And Merge Semantics
+
+This is the most important section.
+
+### 12.1 Central SQLite row upsert behavior
+
+Database writes use `insertOrUpdate()` keyed by the natural row identity:
+
+- teams by `team_number`
+- matches by `comp_level + set_number + match_number + team_key`
+
+Behavior:
+
+- if no row exists for the key, a new row is inserted
+- if a row exists, central updates only the columns present in the incoming `DataRecord`
+
+This means sync is row-based upsert, not append-only.
+
+### 12.2 What gets overwritten on re-sync
+
+If a scout re-syncs the same scouting item:
+
+- the latest incoming values overwrite the existing row’s values for the fields included in the payload
+- fields not included in the incoming payload are left as they were
+
+In practice, scout normally stores and sends the full result object for an item, because `provideResults()` replaces the local cached result for that item before sync. So repeated sync of the same item usually behaves like “last full result wins.”
+
+### 12.3 Raw result cache overwrite behavior on central
+
+Central also stores raw result payloads in:
+
+- `DataInfo.team_results_`
+- `DataInfo.match_results_`
+
+`DataManager.mergeResults()` uses `item` as the unique key:
+
+- new `item` -> append
+- existing `item` -> replace the stored payload with the incoming one
+
+So the raw result cache is also “last result for this item wins.”
+
+### 12.4 Tablet down-sync conflict behavior
+
+When scout receives `ProvideMatchResults` or `ProvideTeamResults`, it only inserts a remote result if the local tablet does not already have that item in `results_`.
+
+That means:
+
+- central data backfills missing local items
+- central does not overwrite an existing local scout result during down-sync
+
+So for scout tablets, local existing data wins over remote during the download phase.
+
+### 12.5 Team result cache behavior on scout
+
+Scout keeps a separate `team_results_cache_`.
+
+Behavior:
+
+- when synced team results arrive, the cache entry is replaced if the `item` already exists
+- match forms can read the active team result from that cache
+
+This cache is not the canonical source on central; it is a local convenience cache on scout.
+
+### 12.6 Coach sync overwrite behavior
+
+Coach sync is much more blunt than scout sync.
+
+Central sends entire files:
+
+- `event.json`
+- `team.db`
+- `match.db`
+
+Coach writes them directly to disk, overwriting the local copies for that event UUID.
+
+So for coach:
+
+- the central project metadata overwrites local event metadata
+- the entire SQLite databases overwrite local SQLite databases
+
+There is no row-level merge for those DB files on coach.
+
+### 12.7 Coach-owned config up-sync behavior
+
+Before coach requests the project and DB files, it sends:
+
+- `ProvideCoachGraphs`
+- `ProvideCoachPickLists`
+
+Central stores only coach-owned data from those payloads:
+
+- graph configs are written into `graph_mgr_.coachConfigs`
+- picklists are filtered to `owner === 'coach'` before replacing `picklist_mgr_.coachesPicklists`
+
+That means:
+
+- coach-owned graph/picklist config is pushed up to central
+- central-owned graph/picklist config is not overwritten by coach
+- for coach-owned config, the incoming coach payload effectively replaces the previous stored coach-owned set
+
+### 12.8 Focused snippet: partial row overwrite
+
+The row update query is assembled only from the fields present in the incoming `DataRecord`.
+
+```ts
+for(let key of dr.keys()) {
+    if (!keys.includes(key)) {
+        query += key + '= ?' ;
+        params.push(DataValue.toSQLite3Value(v!)) ;
+    }
+}
+```
+
+That detail matters because it means:
+
+- sync does not automatically null out omitted columns
+- a partial incoming payload can leave old values behind in columns it does not mention
+
+That is why the practical behavior depends on whether the scout payload is effectively “full item state” or only a partial subset of fields.
+
+## 13. Locking And Initial Database Population
+
+The lock step is what turns an editable event setup into a syncable event with SQLite data.
+
+When central locks an event, it requires:
+
+- teams
+- forms
+- valid tablet assignments
+- optional matches
+
+The lock flow:
+
+1. validate forms
+2. initialize `team.db` and `match.db`
+3. import Blue Alliance team data into `team.db`
+4. import Blue Alliance match schedule into `match.db` if matches exist
+5. generate tablet schedules
+6. remove stale form columns
+7. add current form columns
+8. mark event locked
+9. generate/store event UUID
+10. write `event.json`
+
+That event UUID becomes the identity used by scout and coach sync.
+
+## 14. Manual And UI Database Edits
+
+Central also supports database edits from the DB views through `IPCChange[]`.
+
+Those updates also use `insertOrUpdate()` with a search object as the key selector. So manual DB view edits follow the same general update model:
+
+- find by key fields
+- update the named column
+- insert the row if it does not exist
+
+This is separate from scout sync, but it uses the same lower-level storage primitive.
+
+## 15. Images In Sync
+
+Images are not stored inside SQLite or `event.json`.
+
+They are managed by `ImageManager` and synced separately.
+
+Behavior:
+
+- central reads image files and sends base64 payloads
+- scout and coach write them into their local image cache
+- payloads support both legacy string data and structured objects with `data`, `mimeType`, and `extension`
+
+If an image requested by scout is missing on central, central falls back to the `missing` image asset.
+
+### 15.1 Key image-sync methods
+
+- `SCScout.needImages()`
+  - computes missing images from synced forms
+- `SCCentral.handleRequestRequestImages()`
+  - packages requested images as base64 payloads
+- `SCCoach.computeMissingImages()`
+  - coach-side equivalent for form images
+- `ImageManager.addSyncedImage()`
+  - validates and persists synced image payloads
+
+### 15.2 Focused snippet: central image response shape
+
+```ts
+retdata[img] = {
+    data: fs.readFileSync(info.path).toString('base64'),
+    mimeType: info.mimeType,
+    extension: info.extension,
+} ;
+```
+
+The image layer is deliberately file-based and separate from both SQLite and `event.json`.
+
+### 15.3 Mermaid: image and robot-photo sync path
+
+This is the focused image path used by both scout and coach when forms reference image assets.
+
+```mermaid
+flowchart TD
+    FORM[Local synced forms exist]
+    SCAN[Client scans controls for image references]
+    TYPES[Relevant control types<br/>image, autoplan, autoselector]
+    NAMES[Extract image names<br/>Examples: frc254-front, frc254-side, missing]
+    CACHE{Already in local image cache?}
+    REQUEST[Send RequestImages with only missing names]
+    LOOKUP[Central ImageManager resolves each requested name]
+    FOUND{Image file exists?}
+    READ[Central reads file bytes and encodes base64]
+    FALLBACK[Central substitutes built-in missing image]
+    PACK[Central sends ProvideImages<br/>Example entry: {data, mimeType, extension}]
+    WRITE[Client ImageManager.addSyncedImage writes image file]
+    READY[Forms can render robot photos locally]
+
+    FORM --> SCAN --> TYPES --> NAMES --> CACHE
+    CACHE -->|No missing images| READY
+    CACHE -->|Missing images exist| REQUEST --> LOOKUP --> FOUND
+    FOUND -->|Yes| READ --> PACK
+    FOUND -->|No| FALLBACK --> PACK
+    PACK --> WRITE --> READY
+```
+
+Example robot photo payload shape:
+
+```ts
+{
+  "frc254-front": {
+    "data": "<base64 image bytes>",
+    "mimeType": "image/jpeg",
+    "extension": ".jpg"
+  }
+}
+```
+
+## 16. Failure Handling And Guardrails
+
+### 16.1 Event mismatch
+
+Both scout and coach reject sync if the currently loaded local event UUID does not match the central event UUID.
+
+The user is told to reset the device to sync to the new event.
+
+### 16.2 Invalid stored forms on central
+
+When central receives `RequestTeamForm` or `RequestMatchForm`, it re-validates the stored form file before sending it.
+
+If validation fails:
+
+- central responds with `Error`
+- sync does not continue normally
+
+### 16.3 External-download conflict protection
+
+Central will not let scouts sync while it is downloading data from Blue Alliance or Statbotics. Likewise, central blocks those external downloads while tablets are syncing.
+
+This avoids two writers trying to mutate the project at the same time.
+
+## 17. Practical Summary Of “Who Wins”
+
+### 17.1 Scout downloading from central
+
+- missing local data is filled from central
+- existing local scout result entries are not overwritten by central during the download stage
+
+Winner: local scout result, if it already exists on the tablet
+
+### 17.2 Scout uploading to central
+
+- incoming scout result for an existing `item` replaces the cached raw result payload on central
+- incoming scout result updates the matching SQLite row by natural key
+
+Winner: latest synced scout payload for that `item`
+
+### 17.3 Coach syncing project copy
+
+- central’s `event.json`, `team.db`, and `match.db` replace the coach-local copies
+
+Winner: central
+
+### 17.4 Coach pushing coach-owned configs
+
+- coach-owned graph configs and coach-owned picklists are pushed to central and replace the previous coach-owned stored sets
+- central-owned configs remain central-owned
+
+Winner: coach, but only for coach-owned config domains
+
+## 18. Mermaid: coach sync end-to-end
+
+Coach sync is a different protocol shape from scout sync. It uploads coach-owned config first, then receives a full project replica.
+
+```mermaid
+flowchart TD
+    START[Coach user clicks Sync]
+    CONNECT[Coach opens TCP connection to central]
+    HELLO[Coach sends HelloFromCoach]
+    CHECK{Central accepts sync?}
+    ERR[Central sends Error<br/>Examples: event mismatch or invalid local state]
+    GRAPHS[Coach sends ProvideCoachGraphs<br/>Example: coach-owned graph configs]
+    GRAPHACK[Central sends ReceivedCoachGraphs]
+    PICKS[Coach sends ProvideCoachPickLists<br/>Example: owner=coach picklists]
+    PICKACK[Central sends ReceivedCoachPickLists]
+    PROJECTREQ[Coach requests project copy]
+    PROJECT[Central sends ProvideProject<br/>Example: event.json metadata and raw result cache]
+    TEAMDB[Central sends ProvideTeamDB<br/>Example: full team.db SQLite bytes]
+    MATCHDB[Central sends ProvideMatchDB<br/>Example: full match.db SQLite bytes]
+    TEAMFORM[Central sends ProvideTeamForm<br/>Example: team.json]
+    MATCHFORM[Central sends ProvideMatchForm<br/>Example: match.json]
+    IMGCHK{Any referenced form images missing locally?}
+    IMGREQ[Coach sends RequestImages<br/>Examples: frc254-front, robot-side]
+    IMGS[Central sends ProvideImages]
+    WRITE[Coach writes files under ~/.xeroscout/projects/event-uuid]
+    OPEN[Coach opens the synced project locally]
+    BYE[Coach sends GoodbyeFromCoach]
+    DONE[Sync complete]
+
+    START --> CONNECT --> HELLO --> CHECK
+    CHECK -->|No| ERR
+    CHECK -->|Yes| GRAPHS --> GRAPHACK --> PICKS --> PICKACK --> PROJECTREQ --> PROJECT --> TEAMDB --> MATCHDB --> TEAMFORM --> MATCHFORM --> IMGCHK
+    IMGCHK -->|Yes| IMGREQ --> IMGS --> WRITE
+    IMGCHK -->|No| WRITE
+    WRITE --> OPEN --> BYE --> DONE
+```
+
+## 19. Mermaid: packet-to-data map
+
+This is the quickest way to map each sync packet to the kind of data it moves.
+
+```mermaid
+flowchart TD
+    HELLO[Hello packets]
+    FORMS[Form packets]
+    ASSIGN[Assignment packets]
+    RESULTDOWN[Result download packets]
+    RESULTUP[Result upload packets]
+    IMAGES[Image packets]
+    PLAYOFF[Playoff packets]
+    COACHCFG[Coach config packets]
+    DBFILES[Coach replica packets]
+
+    HELLO --> HELLOEX[Examples<br/>HelloFromScouter, HelloFromCoach<br/>Data: event uuid, event name, tablet identity]
+    FORMS --> FORMEX[Examples<br/>ProvideTeamForm, ProvideMatchForm<br/>Data: team.json, match.json]
+    ASSIGN --> ASSIGNEX[Examples<br/>ProvideTablets, ProvideTeamList, ProvideMatchList<br/>Data: tablet names, team assignments, match assignments]
+    RESULTDOWN --> RESULTDOWNEX[Examples<br/>ProvideTeamResults with st-254<br/>ProvideMatchResults with sm-qm-1-12-254]
+    RESULTUP --> RESULTUPEX[Examples<br/>ProvideResults carrying full local results_ array]
+    IMAGES --> IMAGEEX[Examples<br/>RequestImages for frc254-front<br/>ProvideImages with base64 robot photo payload]
+    PLAYOFF --> PLAYOFFEX[Examples<br/>ProvidePlayoffAssignments, ProvidePlayoffStatus]
+    COACHCFG --> COACHCFGEX[Examples<br/>ProvideCoachGraphs, ProvideCoachPickLists]
+    DBFILES --> DBFILESEX[Examples<br/>ProvideProject event.json<br/>ProvideTeamDB team.db<br/>ProvideMatchDB match.db]
+```
+
+## 20. Important Implementation Consequences
+
+These are the practical implications of the current design.
+
+### 20.1 Scout sync is not delta-based
+
+Scout always uploads its full local `results_` list. If that list grows, the sync payload grows too.
+
+### 20.2 The canonical raw scouting payload lives in `event.json`
+
+SQLite stores processed row values, but central still depends on `event.json` to rehydrate raw result payloads for scouts.
+
+### 20.3 There is no explicit conflict-resolution timestamp
+
+There is no per-field timestamp, revision number, or CRDT-style merge. Conflict behavior is mostly:
+
+- tablet local data is preserved during down-sync
+- latest uploaded result replaces prior central result for the same `item`
+
+### 20.4 Match/team row identity is stable and natural-key based
+
+Because upserts are based on natural keys, repeated syncs modify the same logical row rather than creating duplicates.
+
+### 20.5 Schema is stateful and metadata-backed
+
+The SQLite file is not the only schema source. `ProjectInfo.team_db_info_` and `ProjectInfo.match_db_info_` persist the column descriptors in `event.json`.
+
+That has two consequences:
+
+- the app can describe columns without introspecting SQLite every time
+- schema drift is reconciled by `DataModel.syncColumnNames()`, which removes metadata entries for columns no longer present in the file
+
+### 20.6 Central keeps two parallel representations of scouting data
+
+The system maintains both:
+
+- processed relational rows in SQLite
+- raw result payloads in `event.json`
+
+That duplication is intentional in the current design because scouts need the raw result payload form, not just the flattened row values.
+
+## 21. Code Walkthrough By Responsibility
+
+This section is the quickest way to orient a new engineer in the codebase.
+
+### “Where is a scout result turned into a DB row?”
+
+- team: `TeamDataModel.processScoutingResults()`
+- match: `MatchDataModel.processScoutingResults()`
+
+Those methods convert `IPCScoutResults` entries into `DataRecord`s and call `addColsAndData()`.
+
+### “Where are new DB columns created?”
+
+- `FormManager.populateDBWithForms()`
+- `DataManager.createFormColumns()`
+- `DataModel.createColumns()`
+
+### “Where does central decide what to send?”
+
+- `SCCentral.initPacketHandlers()`
+- `SCCentral.processPacket()`
+
+Those are the central protocol dispatcher and routing table.
+
+### “Where does scout decide what it still needs?”
+
+- `SCScout.needMatchResults()`
+- `SCScout.needTeamResults()`
+- `SCScout.needImages()`
+- `SCScout.getMissingData()`
+
+### “Where does coach do a full-file replica sync?”
+
+- `SCCoach.syncTablet()`
+- `SCCoach.receiveProject()`
+- `SCCoach.receiveTeamDB()`
+- `SCCoach.receiveMatchDB()`
+- `SCCoach.finishSync()`
+
+## 22. Suggested Debugging Path
+
+If sync behavior is wrong and you need to diagnose it quickly, this is the highest-yield order to inspect:
+
+1. Check the structured log file for `SyncPacket`, `ScoutMissingDataRequest`, `CentralResultsReceived`, and `CentralResultsProcessed`.
+2. Confirm the event UUID on both devices matches.
+3. Confirm central is locked and the sync server is running.
+4. Inspect `event.json` on central to see whether the raw result cache was updated.
+5. Inspect `team.db` or `match.db` to see whether the relational row changed.
+6. If scout download behavior is wrong, inspect `needMatchResults()`, `needTeamResults()`, and `getMissingData()`.
+7. If coach sync is wrong, inspect whether `ProvideProject`, `ProvideTeamDB`, and `ProvideMatchDB` were all received and written.
+
+## 23. End-To-End Example
+
+Example: a match scout edits `sm-qm-1-12-254` on a tablet and syncs.
+
+1. tablet saves the edited result into local `results_`
+2. tablet connects to central
+3. central confirms event UUID
+4. tablet fetches any missing forms, assignments, results, images, and playoff data
+5. tablet sends all local results in `ProvideResults`
+6. central converts `sm-qm-1-12-254` into a row keyed by:
+   - `comp_level = qm`
+   - `set_number = 1`
+   - `match_number = 12`
+   - `team_key = frc254`
+7. if that row exists, the incoming fields overwrite the columns present in the payload
+8. central replaces the cached raw `IPCScoutResult` for `sm-qm-1-12-254` in `match_results_`
+9. central persists the updated row in `match.db`
+10. central persists the updated raw cache in `event.json`
+
+## 24. Bottom Line
+
+The current sync model is:
+
+- central is authoritative for event definition, schedules, forms, images, playoff state, and canonical SQLite data
+- scout stores a local JSON cache plus images, fetches missing data from central, and then uploads its full local result set
+- repeated scout syncs are upserts keyed by logical scouting target
+- central keeps both processed SQLite rows and raw last-seen scouting payloads
+- coach receives a full file-level copy of the project databases and metadata, while pushing only coach-owned configs back to central
+
+If you want to reason about overwrites in one sentence:
+
+- scout download is mostly fill-missing-only
+- scout upload is last-result-wins per `item`
+- coach DB sync is whole-file overwrite from central

--- a/main/src/main/apps/sccentral.ts
+++ b/main/src/main/apps/sccentral.ts
@@ -19,6 +19,23 @@ import { IPCAppType, IPCChange, IPCCheckDBViewFormula, IPCColumnDesc, IPCDatabas
 	import { UDPBroadcast } from "../sync/udpbroadcast";
 	import { SCCoachCentralBaseApp } from "./sccoachcentralbase";
 import { createSyncSessionId, logSync, packetSummary, SyncTraceContext } from "../sync/syncdiag";
+import {
+	parseCoachGraphsPayload,
+	parseCoachPicklistsPayload,
+	parseRequestedNamesPayload,
+	parseScoutHelloPayload,
+	parseScoutResultsPayload,
+	stringifyImagesPayload,
+	stringifyHelloResponsePayload,
+	stringifyMatchAssignmentsPayload,
+	stringifyPlayoffAssignmentsPayload,
+	stringifyPlayoffStatusPayload,
+	stringifyProjectInfoPayload,
+	stringifyScoutResultArrayPayload,
+	stringifyTeamAssignmentsPayload,
+	stringifyTabletsPayload,
+	summarizeValidationErrors,
+} from "../../shared/synccontract";
 
 export class SCCentral extends SCCoachCentralBaseApp {
 	private static readonly recentFilesSetting: string = "recent-files";
@@ -1811,16 +1828,33 @@ export class SCCentral extends SCCoachCentralBaseApp {
 	}
 
 	private handleProvideCoachGraphs(p: PacketObj): PacketObj {
-		let obj = JSON.parse(p.payloadAsString()) ;
+		let parsed = parseCoachGraphsPayload(p.payloadAsString()) ;
+		if (!parsed.ok) {
+			return this.validationErrorPacket('ProvideCoachGraphs', parsed.errors) ;
+		}
+		let obj = parsed.value ;
 		this.project!.graph_mgr_!.coachConfigs = obj ;
 		return new PacketObj(PacketType.ReceivedCoachGraphcs, Buffer.from("OK", "utf-8"));
 	}
 
 	private handleProvideCoachPickLists(p: PacketObj): PacketObj {
-		let obj = JSON.parse(p.payloadAsString()) as IPCPickListConfig[] ;
+		let parsed = parseCoachPicklistsPayload(p.payloadAsString()) ;
+		if (!parsed.ok) {
+			return this.validationErrorPacket('ProvideCoachPickLists', parsed.errors) ;
+		}
+		let obj = parsed.value as IPCPickListConfig[] ;
 		const coachOwned = obj.filter((cfg) => cfg.owner === 'coach') ;
 		this.project!.picklist_mgr_!.coachesPicklists = coachOwned ;
 		return new PacketObj(PacketType.ReceivedCoachPickLists, Buffer.from("OK", "utf-8"));
+	}
+
+	private validationErrorPacket(packetName: string, errors: string[]) : PacketObj {
+		this.logSync('warn', 'CentralSyncValidationFailed', {
+			packet: packetName,
+			errorCount: errors.length,
+			errors: errors,
+		}) ;
+		return new PacketObj(PacketType.Error, Buffer.from(`${packetName} validation failed:\n${summarizeValidationErrors(errors)}`, "utf-8")) ;
 	}
 
 	private handleRequestHelloFromScouter(p: PacketObj): PacketObj {
@@ -1841,14 +1875,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 		this.synctype_ = 'data' ;
 		if (p.data_.length > 0) {
-			try {
-				let obj = JSON.parse(p.payloadAsString());
-				this.logSync('info', 'CentralHelloPayload', obj) ;
-			} catch (err) {
-				this.logSync('warn', 'CentralHelloPayloadParseFailed', {
-					message: (err as Error).message,
-				}) ;
+			let parsed = parseScoutHelloPayload(p.payloadAsString()) ;
+			if (!parsed.ok) {
+				return this.validationErrorPacket('HelloFromScouter', parsed.errors) ;
 			}
+			this.logSync('info', 'CentralHelloPayload', parsed.value) ;
 		}
 
 		let evname;
@@ -1870,7 +1901,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 			eventUuid: evid.uuid,
 			eventName: evid.name,
 		}) ;
-		let uuidbuf = Buffer.from(JSON.stringify(evid), "utf-8");
+		let helloPayload = stringifyHelloResponsePayload(evid, 'HelloFromScouter') ;
+		if (!helloPayload.ok) {
+			return this.validationErrorPacket('HelloFromScouter', helloPayload.errors) ;
+		}
+		let uuidbuf = Buffer.from(helloPayload.value, "utf-8");
 		return new PacketObj(PacketType.HelloFromScouter, uuidbuf);
 	}
 
@@ -1899,14 +1934,7 @@ export class SCCentral extends SCCoachCentralBaseApp {
 		else {			
 			this.synctype_ = 'coach' ;
 			if (p.data_.length > 0) {
-				try {
-					let obj = JSON.parse(p.payloadAsString());
-					this.logSync('info', 'CentralCoachHelloPayload', obj) ;
-				} catch (err) {
-					this.logSync('warn', 'CentralCoachHelloPayloadParseFailed', {
-						message: (err as Error).message,
-					}) ;
-				}
+				return this.validationErrorPacket('HelloFromCoach', ['HelloFromCoach must not contain a JSON payload']) ;
 			}
 
 			let evname;
@@ -1928,7 +1956,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 				eventUuid: evid.uuid,
 				eventName: evid.name,
 			}) ;
-			let uuidbuf = Buffer.from(JSON.stringify(evid), "utf-8");
+			let helloPayload = stringifyHelloResponsePayload(evid, 'HelloFromCoach') ;
+			if (!helloPayload.ok) {
+				return this.validationErrorPacket('HelloFromCoach', helloPayload.errors) ;
+			}
+			let uuidbuf = Buffer.from(helloPayload.value, "utf-8");
 			resp = new PacketObj(PacketType.HelloFromCoach, uuidbuf);
 		}
 
@@ -1936,7 +1968,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 	}
 
 	private handleRequestRequestImages(p: PacketObj): PacketObj {
-		let obj : string[] = JSON.parse(p.payloadAsString()) as string[] ;
+		let requested = parseRequestedNamesPayload(p.payloadAsString(), 'RequestImages') ;
+		if (!requested.ok) {
+			return this.validationErrorPacket('RequestImages', requested.errors) ;
+		}
+		let obj : string[] = requested.value ;
 		this.logSync('info', 'CentralProvideImages', {
 			requestedCount: obj.length,
 		}) ;
@@ -1957,13 +1993,21 @@ export class SCCentral extends SCCoachCentralBaseApp {
 		}
 
 		let data: Uint8Array = new Uint8Array(0);
-		let msg : string = JSON.stringify(retdata) ;
+		let imagePayload = stringifyImagesPayload(retdata) ;
+		if (!imagePayload.ok) {
+			return this.validationErrorPacket('ProvideImages', imagePayload.errors) ;
+		}
+		let msg : string = imagePayload.value ;
 		data = Buffer.from(msg, "utf-8");
 		return new PacketObj(PacketType.ProvideImages, data);
 	}	
 
 	private handleRequestMatchResults(p: PacketObj): PacketObj {
-		let obj : string[] = JSON.parse(p.payloadAsString()) as string[] ;
+		let requested = parseRequestedNamesPayload(p.payloadAsString(), 'RequestMatchResults') ;
+		if (!requested.ok) {
+			return this.validationErrorPacket('RequestMatchResults', requested.errors) ;
+		}
+		let obj : string[] = requested.value ;
 		this.logSync('info', 'CentralProvideMatchResults', {
 			requestedCount: obj.length,
 		}) ;
@@ -1975,12 +2019,20 @@ export class SCCentral extends SCCoachCentralBaseApp {
 				results.push(one) ;
 			}
 		}
-		let msg: string = JSON.stringify(results) ;
+		let payload = stringifyScoutResultArrayPayload(results, 'ProvideMatchResults') ;
+		if (!payload.ok) {
+			return this.validationErrorPacket('ProvideMatchResults', payload.errors) ;
+		}
+		let msg: string = payload.value ;
 		return new PacketObj(PacketType.ProvideMatchResults, Buffer.from(msg, "utf-8"));
 	}
 
 	private handleRequestTeamResults(p: PacketObj): PacketObj {
-		let obj : string[] = JSON.parse(p.payloadAsString()) as string[] ;
+		let requested = parseRequestedNamesPayload(p.payloadAsString(), 'RequestTeamResults') ;
+		if (!requested.ok) {
+			return this.validationErrorPacket('RequestTeamResults', requested.errors) ;
+		}
+		let obj : string[] = requested.value ;
 		this.logSync('info', 'CentralProvideTeamResults', {
 			requestedCount: obj.length,
 		}) ;
@@ -1992,7 +2044,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 				results.push(one) ;
 			}
 		}
-		let msg: string = JSON.stringify(results) ;
+		let payload = stringifyScoutResultArrayPayload(results, 'ProvideTeamResults') ;
+		if (!payload.ok) {
+			return this.validationErrorPacket('ProvideTeamResults', payload.errors) ;
+		}
+		let msg: string = payload.value ;
 		return new PacketObj(PacketType.ProvideTeamResults, Buffer.from(msg, "utf-8"));
 	}
 
@@ -2009,7 +2065,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 				}
 			}
 
-			let msg: string = JSON.stringify(tablets);
+			let tabletPayload = stringifyTabletsPayload(tablets) ;
+			if (!tabletPayload.ok) {
+				return this.validationErrorPacket('ProvideTablets', tabletPayload.errors) ;
+			}
+			let msg: string = tabletPayload.value;
 			this.logSync('info', 'CentralProvideTabletsReady', {
 				tabletCount: tablets.length,
 			}) ;
@@ -2074,7 +2134,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 	private handleRequestTeamList(p: PacketObj): PacketObj {
 		if (this.project?.tablet_mgr_?.hasTeamAssignments()) {
-			let str = JSON.stringify(this.project?.tablet_mgr_?.getTeamAssignments());
+			let serialized = stringifyTeamAssignmentsPayload(this.project?.tablet_mgr_?.getTeamAssignments());
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvideTeamList', serialized.errors) ;
+			}
+			let str = serialized.value;
 			return new PacketObj(PacketType.ProvideTeamList, Buffer.from(str));
 		} else {
 			dialog.showErrorBox(
@@ -2093,27 +2157,47 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 	private handleRequestPlayoffAssignments(p: PacketObj): PacketObj {
 		if (this.project?.tablet_mgr_?.hasPlayoffAssignments()) {
-			let str = JSON.stringify(this.project?.tablet_mgr_?.getPlayoffAssignments());
+			let serialized = stringifyPlayoffAssignmentsPayload(this.project?.tablet_mgr_?.getPlayoffAssignments());
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvidePlayoffAssignments', serialized.errors) ;
+			}
+			let str = serialized.value;
 			return new PacketObj(PacketType.ProvidePlayoffAssignments, Buffer.from(str));
 		} else {
-			let str = JSON.stringify(null) ;
+			let serialized = stringifyPlayoffAssignmentsPayload(null) ;
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvidePlayoffAssignments', serialized.errors) ;
+			}
+			let str = serialized.value ;
 			return new PacketObj(PacketType.ProvidePlayoffAssignments, Buffer.from(str));				
 		}
 	}
 
 	private handleRequestPlayoffStatus(p: PacketObj): PacketObj {
 		if (this.project?.playoff_mgr_?.hasPlayoffStatus()) {
-			let str = JSON.stringify(this.project?.playoff_mgr_?.info) ;
+			let serialized = stringifyPlayoffStatusPayload(this.project?.playoff_mgr_?.info) ;
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvidePlayoffStatus', serialized.errors) ;
+			}
+			let str = serialized.value ;
 			return new PacketObj(PacketType.ProvidePlayoffStatus, Buffer.from(str));
 		} else {
-			let str = JSON.stringify(null) ;
+			let serialized = stringifyPlayoffStatusPayload(null) ;
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvidePlayoffStatus', serialized.errors) ;
+			}
+			let str = serialized.value ;
 			return new PacketObj(PacketType.ProvidePlayoffStatus, Buffer.from(str));
 		}
 	}
 
 	private handleRequestMatchList(p: PacketObj): PacketObj {
 		if (this.project?.tablet_mgr_?.hasMatchAssignments()) {
-			let str = JSON.stringify(this.project?.tablet_mgr_?.getMatchAssignments());
+			let serialized = stringifyMatchAssignmentsPayload(this.project?.tablet_mgr_?.getMatchAssignments());
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvideMatchList', serialized.errors) ;
+			}
+			let str = serialized.value;
 			return new PacketObj(PacketType.ProvideMatchList, Buffer.from(str));
 		} else {
 			let str = JSON.stringify([]) ;
@@ -2123,7 +2207,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 	private async handleProvideResults(p: PacketObj): Promise<PacketObj> {
 		try {
-			let obj : IPCScoutResults = JSON.parse(p.payloadAsString()) as IPCScoutResults ;
+			let parsed = parseScoutResultsPayload(p.payloadAsString()) ;
+			if (!parsed.ok) {
+				return this.validationErrorPacket('ProvideResults', parsed.errors) ;
+			}
+			let obj : IPCScoutResults = parsed.value ;
 			this.logSync('info', 'CentralResultsReceived', {
 				tablet: obj.tablet,
 				purpose: obj.purpose,
@@ -2162,7 +2250,11 @@ export class SCCentral extends SCCoachCentralBaseApp {
 
 	private handleRequestProject(p: PacketObj): PacketObj | undefined {
 		if (this.project) {
-			let msg = JSON.stringify(this.project.info) ;
+			let serialized = stringifyProjectInfoPayload(this.project.info) ;
+			if (!serialized.ok) {
+				return this.validationErrorPacket('ProvideProject', serialized.errors) ;
+			}
+			let msg = serialized.value ;
 			return new PacketObj(PacketType.ProvideProject, Buffer.from(msg, "utf-8"));
 		}
 		return undefined;

--- a/main/src/main/apps/sccoach.ts
+++ b/main/src/main/apps/sccoach.ts
@@ -8,6 +8,17 @@ import { PacketType } from "../sync/packettypes";
 import { Project } from "../project/project";
 import { SCCoachCentralBaseApp } from "./sccoachcentralbase";
 import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCImageItem, IPCPickListConfig, IPCSyncedImageData } from "../../shared/ipc";
+import {
+    parseFormPayload,
+    parseHelloResponsePayload,
+    parseImagesPayload,
+    parseProjectInfoPayload,
+    stringifyCoachGraphsPayload,
+    stringifyCoachPicklistsPayload,
+    stringifyStringArrayPayload,
+    summarizeValidationErrors,
+    validateCoachSyncPreflight,
+} from "../../shared/synccontract";
 
 export class SCCoach extends SCCoachCentralBaseApp {
     private static readonly lastEventLoaded: string = 'coach-last-event-loaded' ;
@@ -415,6 +426,14 @@ export class SCCoach extends SCCoachCentralBaseApp {
         this.awaiting_images_ = false ;
         this.sync_finalized_ = false ;
 
+        const configs = this.project?.graph_mgr_?.coachConfigs || [] ;
+        const picklists = this.project?.picklist_mgr_?.coachesPicklists || [] ;
+        const preflight = validateCoachSyncPreflight(configs, picklists) ;
+        if (!preflight.ok) {
+            this.showSyncValidationError('Invalid Local Sync Data', preflight.errors) ;
+            return ;
+        }
+
         this.sync_client_!.connect()
             .then(async ()=> {
                 this.logger_.info(`ScouterSync: connected to server ' ${this.sync_client_!.name()}'`) ;
@@ -454,8 +473,13 @@ export class SCCoach extends SCCoachCentralBaseApp {
                 
             })
             .catch((err) => {
-                this.logger_.error('Error connecting to sync server: ' + err.message) ;
+            this.logger_.error('Error connecting to sync server: ' + err.message) ;
             }) ;
+    }
+
+    private showSyncValidationError(title: string, errors: string[]) : void {
+        dialog.showErrorBox(title, summarizeValidationErrors(errors)) ;
+        this.logger_.error(`${title}: ${errors.join(" | ")}`) ;
     }
 
     private normalizeImageName(name: string) : string {
@@ -532,8 +556,13 @@ export class SCCoach extends SCCoachCentralBaseApp {
     private maybeRequestImagesOrCompleteSync() : void {
         let missing = this.computeMissingImages() ;
         if (missing.length > 0) {
+            const serialized = stringifyStringArrayPayload(missing, 'RequestImages') ;
+            if (!serialized.ok) {
+                this.showSyncValidationError('Invalid Local Sync Data', serialized.errors) ;
+                return ;
+            }
             this.awaiting_images_ = true ;
-            let payload = Buffer.from(JSON.stringify(missing), 'utf-8') ;
+            let payload = Buffer.from(serialized.value, 'utf-8') ;
             this.sync_client_!.send(new PacketObj(PacketType.RequestImages, payload)) ;
         }
         else {
@@ -560,7 +589,13 @@ export class SCCoach extends SCCoachCentralBaseApp {
             case PacketType.HelloFromCoach:
                 this.receiveHello(p) ;
                 let configs = this.project?.graph_mgr_?.coachConfigs || [] ;
-                str = JSON.stringify(configs) ;
+                let configPayload = stringifyCoachGraphsPayload(configs) ;
+                if (!configPayload.ok) {
+                    this.showSyncValidationError('Invalid Local Sync Data', configPayload.errors) ;
+                    this.sync_client_?.close() ;
+                    return ;
+                }
+                str = configPayload.value ;
                 data = new Uint8Array(Buffer.from(str)) ;
                 p = new PacketObj(PacketType.ProvideCoachGraphs, data) ;
                 this.sync_client_!.send(p) ;
@@ -569,7 +604,13 @@ export class SCCoach extends SCCoachCentralBaseApp {
             case PacketType.ReceivedCoachGraphcs:
                 this.logger_.debug('SyncTablet: received ReceivedCoachGraphcs packet') ;
                 let picklists = this.project?.picklist_mgr_?.coachesPicklists || [] ;
-                str = JSON.stringify(picklists) ;
+                let picklistPayload = stringifyCoachPicklistsPayload(picklists) ;
+                if (!picklistPayload.ok) {
+                    this.showSyncValidationError('Invalid Local Sync Data', picklistPayload.errors) ;
+                    this.sync_client_?.close() ;
+                    return ;
+                }
+                str = picklistPayload.value ;
                 data = new Uint8Array(Buffer.from(str)) ;
                 p = new PacketObj(PacketType.ProvideCoachPickLists, data) ;
                 this.sync_client_!.send(p) ;
@@ -589,7 +630,10 @@ export class SCCoach extends SCCoachCentralBaseApp {
                 this.sync_client_!.send(p) ;                   
                 break ;
             case PacketType.ProvideProject:
-                this.receiveProject(p) ;
+                if (!this.receiveProject(p)) {
+                    this.sync_client_?.close() ;
+                    return ;
+                }
                 p = new PacketObj(PacketType.RequestTeamDB, new Uint8Array(0)) ;
                 this.sync_client_!.send(p) ;                
                 break ;
@@ -608,11 +652,13 @@ export class SCCoach extends SCCoachCentralBaseApp {
 
             case PacketType.ProvideTeamForm:
                 this.logger_.debug('SyncTablet: received ProvideTeamForm packet') ;
-                try {
-                    this.team_form_ = JSON.parse(p.payloadAsString()) as IPCForm ;
-                }
-                catch {
-                    this.team_form_ = undefined ;
+                {
+                    const parsed = parseFormPayload(p.payloadAsString(), 'ProvideTeamForm') ;
+                    if (!parsed.ok) {
+                        this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                        return ;
+                    }
+                    this.team_form_ = parsed.value ;
                 }
                 this.receiveTeamForm(p) ;
                 p = new PacketObj(PacketType.RequestMatchForm, new Uint8Array(0)) ;
@@ -621,36 +667,35 @@ export class SCCoach extends SCCoachCentralBaseApp {
 
             case PacketType.ProvideMatchForm:
                 this.logger_.debug('SyncTablet: received ProvideMatchForm packet') ;
-                try {
-                    this.match_form_ = JSON.parse(p.payloadAsString()) as IPCForm ;
-                }
-                catch {
-                    this.match_form_ = undefined ;
+                {
+                    const parsed = parseFormPayload(p.payloadAsString(), 'ProvideMatchForm') ;
+                    if (!parsed.ok) {
+                        this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                        return ;
+                    }
+                    this.match_form_ = parsed.value ;
                 }
                 this.receiveMatchForm(p) ;
                 this.maybeRequestImagesOrCompleteSync() ;
                 break ;
 
             case PacketType.ProvideImages:
-                try {
-                    let obj = JSON.parse(p.payloadAsString()) as unknown ;
-                    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
-                        this.logger_.warn('SyncTablet: received invalid ProvideImages payload shape') ;
-                        break ;
+                {
+                    const parsed = parseImagesPayload(p.payloadAsString()) ;
+                    if (!parsed.ok) {
+                        this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                        return ;
                     }
 
-                    for (let imname of Object.keys(obj)) {
+                    for (let imname of Object.keys(parsed.value)) {
                         let norm = this.normalizeImageName(imname) ;
                         if (norm.length > 0) {
-                            const result = this.image_mgr_.addSyncedImage(norm, (obj as Record<string, unknown>)[imname]) ;
+                            const result = this.image_mgr_.addSyncedImage(norm, parsed.value[imname]) ;
                             if (!result.ok) {
                                 this.logger_.warn(`SyncTablet: skipping synced image '${norm}' - ${result.reason}`) ;
                             }
                         }
                     }
-                }
-                catch {
-                    this.logger_.warn('SyncTablet: received invalid ProvideImages payload JSON') ;
                 }
                 this.awaiting_images_ = false ;
                 this.completeSync() ;
@@ -675,23 +720,23 @@ export class SCCoach extends SCCoachCentralBaseApp {
 
     private receiveHello(p: PacketObj) : void {
         this.logger_.debug('SyncTablet: received HelloFromCoach packet') ;
-        try {
-            let obj = JSON.parse(p.payloadAsString()) ;
-            if (this.project && this.project.info?.uuid_ && obj.uuid !== this.project.info.uuid_) {
-                dialog.showMessageBoxSync(this.win_, {
-                    title: 'Synchronization Error',
-                    message: 'The connected event does not match the currently loaded event.\nReset the Coach tablet to sync to this new event.',
-                    type: 'error'
-                }) ;
-                //
-                // We have an event loaded and it does not match
-                //
-                this.sync_client_!!.close() ;
-                return ;
-            }
+        const parsed = parseHelloResponsePayload(p.payloadAsString(), 'HelloFromCoach') ;
+        if (!parsed.ok) {
+            this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+            this.sync_client_?.close() ;
+            return ;
         }
-        catch(err) {
-        }    
+
+        let obj = parsed.value ;
+        if (this.project && this.project.info?.uuid_ && obj.uuid !== this.project.info.uuid_) {
+            dialog.showMessageBoxSync(this.win_, {
+                title: 'Synchronization Error',
+                message: 'The connected event does not match the currently loaded event.\nReset the Coach tablet to sync to this new event.',
+                type: 'error'
+            }) ;
+            this.sync_client_!!.close() ;
+            return ;
+        }
     }
 
     private receiveTeamForm(p: PacketObj) : void {
@@ -706,10 +751,15 @@ export class SCCoach extends SCCoachCentralBaseApp {
         fs.writeFileSync(fname, str) ;
     }
 
-    private receiveProject(p: PacketObj) : void {
+    private receiveProject(p: PacketObj) : boolean {
         this.logger_.debug('SyncTablet: received ProvideProject packet') ;        
         let str : string = p.payloadAsString() ;
-        let info : any = JSON.parse(str) ;
+        const parsed = parseProjectInfoPayload(str) ;
+        if (!parsed.ok) {
+            this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+            return false ;
+        }
+        let info : any = parsed.value ;
         this.sync_project_file_ = this.getProjectDir(info) ;
 
         if (!fs.existsSync(this.sync_project_file_)) {
@@ -717,6 +767,7 @@ export class SCCoach extends SCCoachCentralBaseApp {
         }
 
         fs.writeFileSync(path.join(this.sync_project_file_, 'event.json'), str) ;
+        return true ;
     }
 
     public override savePicklistConfig(configs: IPCPickListConfig[]) {

--- a/main/src/main/apps/sccoach.ts
+++ b/main/src/main/apps/sccoach.ts
@@ -258,7 +258,7 @@ export class SCCoach extends SCCoachCentralBaseApp {
             this.syncCoach() ;            
         }
         else if (cmd === SCCoach.syncEventRemote) {
-            this.sync_client_ = new TCPClient(this.logger_, this.sync_ipaddr_, this.sync_port_) ;
+            this.sync_client_ = new TCPClient(this.logger_, SCCoach.defaultSyncIPAddr, this.sync_port_) ;
             this.sync_client_?.on('close', this.syncDone.bind(this)) ; 
             this.sync_client_?.on('error', this.syncError.bind(this)) ;
             this.syncCoach() ;
@@ -332,7 +332,7 @@ export class SCCoach extends SCCoachCentralBaseApp {
 
         synctcpitem = new MenuItem( {
             type: 'normal',
-            label: 'Sync Event Cable (Last Sync Address)',
+            label: 'Sync Event Cable (192.168.1.1)',
             click: () => { this.executeCommand(SCCoach.syncEventRemote)}
         }) ;
         filemenu.submenu?.insert(1, synctcpitem) ;

--- a/main/src/main/apps/scscout.ts
+++ b/main/src/main/apps/scscout.ts
@@ -10,6 +10,23 @@ import { MatchTablet, PlayoffAssignment, TeamTablet } from "../project/tabletmgr
 import { kMatchAlliances } from '../../shared/playoffs';
 import { IPCAppType, IPCAutoPlanItem, IPCAutoSelectorItem, IPCForm, IPCFormScoutData, IPCImageItem, IPCNamedDataValue, IPCPlayoffStatus, IPCScoutResult, IPCScoutResults, IPCSection, IPCTabletDefn } from "../../shared/ipc";
 import { createSyncSessionId, logSync, packetSummary, SyncTraceContext } from "../sync/syncdiag";
+import {
+    parseFormPayload,
+    parseHelloResponsePayload,
+    parseImagesPayload,
+    parseMatchAssignmentsPayload,
+    parsePlayoffAssignmentsPayload,
+    parsePlayoffStatusPayload,
+    parseScoutHelloPayload,
+    parseScoutResultArrayPayload,
+    parseTabletsPayload,
+    parseTeamAssignmentsPayload,
+    stringifyScoutHelloPayload,
+    stringifyScoutResultsPayload,
+    stringifyStringArrayPayload,
+    summarizeValidationErrors,
+    validateScoutSyncPreflight,
+} from "../../shared/synccontract";
 
 export class SCScoutInfo {
     public tablet_? : string ;
@@ -656,9 +673,38 @@ export class SCScout extends SCBase {
         return ret;
     }
 
+    private buildScoutResultsPayload() : IPCScoutResults {
+        return {
+            tablet: this.info_.tablet_!,
+            purpose: this.info_.purpose_!,
+            results: this.info_.results_
+        } ;
+    }
+
+    private showSyncValidationError(title: string, errors: string[]) {
+        const message = summarizeValidationErrors(errors) ;
+        this.logSync('error', 'ScoutSyncValidationFailed', {
+            title: title,
+            errorCount: errors.length,
+            errors: errors,
+        }) ;
+        this.sendToRenderer('set-status-title', title) ;
+        this.sendToRenderer('set-status-visible', true) ;
+        this.sendToRenderer('set-status-text', message) ;
+        this.sendToRenderer('set-status-close-button-visible', true) ;
+    }
+
     private syncClient(conn: SyncClient) {
         this.optionallyGetResults()
         .then(() => {
+            if (this.info_.tablet_ && this.info_.purpose_) {
+                const preflight = validateScoutSyncPreflight(this.buildScoutResultsPayload()) ;
+                if (!preflight.ok) {
+                    this.showSyncValidationError('Invalid Local Sync Data', preflight.errors) ;
+                    return ;
+                }
+            }
+
             this.match_results_received_ = false ;
             this.team_results_received_ = false ;
             this.team_form_received_ = false ;
@@ -687,7 +733,13 @@ export class SCScout extends SCBase {
                             name: this.info_.tablet_,
                             purpose: this.info_.purpose_
                         }
-                        data = Buffer.from(JSON.stringify(obj)) ;
+                        const helloPayload = stringifyScoutHelloPayload(obj) ;
+                        if (!helloPayload.ok) {
+                            this.showSyncValidationError('Invalid Local Sync Data', helloPayload.errors) ;
+                            this.conn_?.close() ;
+                            return ;
+                        }
+                        data = Buffer.from(helloPayload.value) ;
                     }
                     this.refreshSyncTrace() ;
                     this.conn_!.setTraceContext(this.sync_trace_) ;
@@ -753,10 +805,14 @@ export class SCScout extends SCBase {
         this.logSync('info', 'ScoutPacketReceived', packetSummary(p)) ;
 
         if (p.type_ === PacketType.HelloFromScouter) {
-            let obj ;
+            const parsed = parseHelloResponsePayload(p.payloadAsString(), 'HelloFromScouter') ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                this.conn_?.close() ;
+                return ;
+            }
 
-            try {
-                obj = JSON.parse(p.payloadAsString()) ;
+            const obj = parsed.value ;
                 if (this.info_.uuid_ && obj.uuid !== this.info_.uuid_) {
                     //
                     // We have an event loaded and it does not match
@@ -794,43 +850,61 @@ export class SCScout extends SCBase {
                     this.logSync('info', 'ScoutRequestingTablets', packetSummary(p)) ;
                     this.conn_!.send(p) ;
                 }
-            }
-            catch(err) {
-                this.logSync('error', 'ScoutHelloParseFailed', {
-                    message: (err as Error).message,
-                    payloadPreview: p.payloadAsString(),
-                }) ;
-            }
         }
         else if (p.type_ === PacketType.ProvideTablets) {
-            this.tablets_ = JSON.parse(p.data_.toString()) ;
+            const parsed = parseTabletsPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            this.tablets_ = parsed.value ;
             this.logSync('info', 'ScoutTabletsReceived', {
                 tabletCount: this.tablets_?.length ?? 0,
             }) ;
             this.setView('select-tablet') ;
         }
         else if (p.type_ === PacketType.ProvideTeamForm) {
-            this.info_.teamform_ = JSON.parse(p.payloadAsString()) ;
+            const parsed = parseFormPayload(p.payloadAsString(), 'ProvideTeamForm') ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            this.info_.teamform_ = parsed.value ;
             this.team_form_received_ = true ;
             this.writeEventFile() ;
             ret = this.getMissingData() ;            
         }
         else if (p.type_ === PacketType.ProvideMatchForm) {
-            this.info_.matchform_ = JSON.parse(p.payloadAsString()) ;
+            const parsed = parseFormPayload(p.payloadAsString(), 'ProvideMatchForm') ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            this.info_.matchform_ = parsed.value ;
             this.match_form_received_ = true ;
             this.writeEventFile() ;
             ret = this.getMissingData() ;  
         }
         else if (p.type_ === PacketType.ProvideTeamList) {
-            this.info_.teamlist_ = JSON.parse(p.payloadAsString()) ;
+            const parsed = parseTeamAssignmentsPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            this.info_.teamlist_ = parsed.value as TeamTablet[] ;
             this.team_list_received_ = true ;
             this.writeEventFile() ;
             ret = this.getMissingData() ;  
         }
         else if (p.type_ === PacketType.ProvidePlayoffAssignments) {
-            let obj = JSON.parse(p.payloadAsString()) ;
+            const parsed = parsePlayoffAssignmentsPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            let obj = parsed.value ;
             if (obj !== null) {
-                this.info_.playoff_assignments_ = obj ;
+                this.info_.playoff_assignments_ = obj as PlayoffAssignment[] ;
                 this.writeEventFile() ;
                 this.checkPlayoffMatchGeneration();
             }
@@ -843,7 +917,12 @@ export class SCScout extends SCBase {
             this.getMissingData() ;
         }
         else if (p.type_ === PacketType.ProvidePlayoffStatus) {
-            let obj = JSON.parse(p.payloadAsString()) ;
+            const parsed = parsePlayoffStatusPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            let obj = parsed.value ;
             if (obj !== null) {
                 this.info_.playoff_status_ = obj ;
                 this.writeEventFile() ;
@@ -858,32 +937,30 @@ export class SCScout extends SCBase {
             this.getMissingData() ;
         }        
         else if (p.type_ === PacketType.ProvideMatchList) {
-            this.info_.matchlist_ = JSON.parse(p.payloadAsString()) ;
+            const parsed = parseMatchAssignmentsPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            this.info_.matchlist_ = parsed.value as MatchTablet[] ;
             this.match_list_received_ = true ;
             this.writeEventFile() ;
             ret = this.getMissingData() ;  
         }
         else if (p.type_ === PacketType.ProvideImages) {
-            let obj: unknown ;
-            try {
-                obj = JSON.parse(p.payloadAsString()) ;
-            }
-            catch (err) {
-                this.logger_.warn('SyncTablet: received invalid ProvideImages payload JSON') ;
-                this.logSync('warn', 'ScoutProvideImagesInvalidJson') ;
+            const parsed = parseImagesPayload(p.payloadAsString()) ;
+            if (!parsed.ok) {
+                this.logSync('warn', 'ScoutProvideImagesInvalidShape', {
+                    errors: parsed.errors,
+                }) ;
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
                 ret = this.getMissingData() ;
                 return ;
             }
 
-            if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
-                this.logger_.warn('SyncTablet: received invalid ProvideImages payload shape') ;
-                this.logSync('warn', 'ScoutProvideImagesInvalidShape') ;
-                ret = this.getMissingData() ;
-                return ;
-            }
-
+            const obj = parsed.value ;
             for (let imname of Object.keys(obj)) {
-                const result = this.image_mgr_.addSyncedImage(imname, (obj as Record<string, unknown>)[imname]) ;
+                const result = this.image_mgr_.addSyncedImage(imname, obj[imname]) ;
                 if (!result.ok) {
                     this.logger_.warn(`SyncTablet: skipping synced image '${imname}' - ${result.reason}`) ;
                 }
@@ -891,10 +968,15 @@ export class SCScout extends SCBase {
             ret = this.getMissingData() ;  
         }
         else if (p.type_ === PacketType.ProvideMatchResults) {
+            const parsed = parseScoutResultArrayPayload(p.payloadAsString(), 'ProvideMatchResults') ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
             if (this.info_.purpose_ === 'match') {
-                let obj = JSON.parse(p.payloadAsString()) ;
+                let obj = parsed.value ;
                 for(let res of obj) {
-                    if (!this.getOneScoutResults(res.item)) {
+                    if (res.item && !this.getOneScoutResults(res.item)) {
                         this.addResults(res.item, res.data) ;
                     }
                 }
@@ -904,7 +986,12 @@ export class SCScout extends SCBase {
             ret = this.getMissingData() ;  
         }
         else if (p.type_ === PacketType.ProvideTeamResults) {
-            let obj = JSON.parse(p.payloadAsString()) as IPCScoutResult[] ;
+            const parsed = parseScoutResultArrayPayload(p.payloadAsString(), 'ProvideTeamResults') ;
+            if (!parsed.ok) {
+                this.showSyncValidationError('Invalid Sync Data From Central', parsed.errors) ;
+                return ;
+            }
+            let obj = parsed.value ;
             for(let res of obj) {
                 if (!res.item) {
                     continue ;
@@ -942,13 +1029,15 @@ export class SCScout extends SCBase {
     }
 
     private sendScoutingData() {
-        let obj : IPCScoutResults = {
-            tablet: this.info_.tablet_!,
-            purpose: this.info_.purpose_!,
-            results: this.info_.results_
-        } ;
+        let obj : IPCScoutResults = this.buildScoutResultsPayload() ;
+        let serialized = stringifyScoutResultsPayload(obj) ;
+        if (!serialized.ok) {
+            this.showSyncValidationError('Invalid Local Sync Data', serialized.errors) ;
+            this.conn_?.close() ;
+            return ;
+        }
 
-        let jsonstr = JSON.stringify(obj) ;
+        let jsonstr = serialized.value ;
         this.logSync('info', 'ScoutSendingResults', {
             tablet: obj.tablet,
             purpose: obj.purpose,
@@ -1101,32 +1190,47 @@ export class SCScout extends SCBase {
         }
         else if (!this.match_results_received_ && this.needMatchResults().length > 0) {
             const missing = this.needMatchResults() ;
+            const payload = stringifyStringArrayPayload(missing, 'RequestMatchResults') ;
+            if (!payload.ok) {
+                this.showSyncValidationError('Invalid Local Sync Data', payload.errors) ;
+                return ret ;
+            }
             this.logSync('debug', 'ScoutMissingDataRequest', {
                 nextRequest: 'RequestMatchResults',
                 requestedCount: missing.length,
                 state: this.getSyncStateSnapshot(),
             }) ;
-            this.conn_?.send(new PacketObj(PacketType.RequestMatchResults, Buffer.from(JSON.stringify(missing)))) ;
+            this.conn_?.send(new PacketObj(PacketType.RequestMatchResults, Buffer.from(payload.value))) ;
             ret = true ;
         }
         else if (!this.team_results_received_ && this.needTeamResults().length > 0) {
             const missing = this.needTeamResults() ;
+            const payload = stringifyStringArrayPayload(missing, 'RequestTeamResults') ;
+            if (!payload.ok) {
+                this.showSyncValidationError('Invalid Local Sync Data', payload.errors) ;
+                return ret ;
+            }
             this.logSync('debug', 'ScoutMissingDataRequest', {
                 nextRequest: 'RequestTeamResults',
                 requestedCount: missing.length,
                 state: this.getSyncStateSnapshot(),
             }) ;
-            this.conn_?.send(new PacketObj(PacketType.RequestTeamResults, Buffer.from(JSON.stringify(missing)))) ;
+            this.conn_?.send(new PacketObj(PacketType.RequestTeamResults, Buffer.from(payload.value))) ;
             ret = true ;
         }
         else if (this.needImages().length > 0) {
             const missing = this.needImages() ;
+            const payload = stringifyStringArrayPayload(missing, 'RequestImages') ;
+            if (!payload.ok) {
+                this.showSyncValidationError('Invalid Local Sync Data', payload.errors) ;
+                return ret ;
+            }
             this.logSync('debug', 'ScoutMissingDataRequest', {
                 nextRequest: 'RequestImages',
                 requestedCount: missing.length,
                 state: this.getSyncStateSnapshot(),
             }) ;
-            this.conn_?.send(new PacketObj(PacketType.RequestImages, Buffer.from(JSON.stringify(missing)))) ;
+            this.conn_?.send(new PacketObj(PacketType.RequestImages, Buffer.from(payload.value))) ;
             ret = true ;            
         }
         else if (!this.info_.playoff_assignments_ && !this.playoff_assignment_received_) {

--- a/main/src/main/apps/scscout.ts
+++ b/main/src/main/apps/scscout.ts
@@ -297,8 +297,8 @@ export class SCScout extends SCBase {
         else if (cmd === SCScout.syncEventRemote) {
             this.setViewString() ;
             this.current_scout_ = undefined ;
-            this.beginSyncTrace('cable', this.ipaddr_, this.port_) ;
-            this.sync_client_ = new TCPClient(this.logger_, this.ipaddr_, this.port_) ;
+            this.beginSyncTrace('cable', SCScout.defaultSyncIPAddr, this.port_) ;
+            this.sync_client_ = new TCPClient(this.logger_, SCScout.defaultSyncIPAddr, this.port_) ;
             this.sync_client_.on('close', this.syncDone.bind(this)) ; 
             this.sync_client_.on('error', this.syncError.bind(this)) ;
 
@@ -1209,7 +1209,7 @@ export class SCScout extends SCBase {
 
         synctcpitem = new MenuItem( {
             type: 'normal',
-            label: 'Sync Event Cable (Last Sync Address)',
+            label: 'Sync Event Cable (192.168.1.1)',
             click: () => { this.executeCommand(SCScout.syncEventRemote)}
         }) ;
         filemenu.submenu?.insert(1, synctcpitem) ;

--- a/main/src/main/apps/scscout.ts
+++ b/main/src/main/apps/scscout.ts
@@ -71,6 +71,7 @@ export class SCScout extends SCBase {
     private info_ : SCScoutInfo = new SCScoutInfo() ;
 
     private resultPromiseResolve_ ? : () => void ;
+    private pending_result_request_item_?: string ;
     private tablets_?: IPCTabletDefn[] ;
     private conn_?: SyncClient ;
     private current_scout_? : string ;
@@ -590,10 +591,11 @@ export class SCScout extends SCBase {
     }
 
     public provideResults(res: IPCNamedDataValue[], scoutItem?: string) {
-        const effectiveScoutItem = scoutItem ?? this.current_scout_ ;
+        const effectiveScoutItem = scoutItem ?? this.pending_result_request_item_ ?? this.current_scout_ ;
         this.logSync('debug', 'ScoutProvideResults', {
             currentScout: this.current_scout_,
             requestedScoutItem: scoutItem,
+            pendingRequestedScoutItem: this.pending_result_request_item_ ?? null,
             effectiveScoutItem: effectiveScoutItem,
             resultCount: res.length,
         }) ;
@@ -613,6 +615,7 @@ export class SCScout extends SCBase {
                 this.resultPromiseResolve_() ;
                 this.resultPromiseResolve_ = undefined ;
             }
+            this.pending_result_request_item_ = undefined ;
             return ;
         }
 
@@ -625,6 +628,7 @@ export class SCScout extends SCBase {
             this.resultPromiseResolve_() ;
             this.resultPromiseResolve_ = undefined ;
         }
+        this.pending_result_request_item_ = undefined ;
     }
 
     public sendForm(type: string) {
@@ -640,7 +644,7 @@ export class SCScout extends SCBase {
             color: this.alliance_,
             title: this.current_scout_,
             draftKey: this.createDraftKey(type, this.current_scout_),
-            initialValues: this.cloneNamedDataValues(data?.data),
+            initialValues: this.cloneNamedDataValues(data?.data) ?? [],
             eventUuid: this.info_.uuid_,
             scoutItem: this.current_scout_,
         }
@@ -754,6 +758,7 @@ export class SCScout extends SCBase {
     private getCurrentResults() : Promise<void> {
         let ret = new Promise<void>((resolve, reject) => {
             this.resultPromiseResolve_ = resolve ;
+            this.pending_result_request_item_ = this.current_scout_ ;
             this.sendToRenderer('request-results', { scoutItem: this.current_scout_ }) ;
         }) ;
         return ret;

--- a/main/src/main/apps/scscout.ts
+++ b/main/src/main/apps/scscout.ts
@@ -60,6 +60,7 @@ export class SCScout extends SCBase {
     private static readonly syncEventRemote: string = "sync-event-remote" ;
     private static readonly syncEventWiFi: string = "sync-event-wifi" ;
     private static readonly syncEventIPAddr: string = "sync-event-ipaddr" ;
+    private static readonly resetCurrentMatch: string = "reset-current-match" ;
     private static readonly resetTablet: string = "reset-tablet" ;
     private static readonly resizeWindow: string = "resize-window" ;
     private static readonly showTeams: string = 'show-teams' ;
@@ -289,6 +290,11 @@ export class SCScout extends SCBase {
     }
 
     public executeCommand(cmd: string) : void {   
+        if (cmd === SCScout.resetCurrentMatch) {
+            this.executeCommandInternal(cmd) ;
+            return ;
+        }
+
         this.optionallyGetResults()
         .then(() => {
             this.executeCommandInternal(cmd) ;
@@ -338,7 +344,10 @@ export class SCScout extends SCBase {
         else if (cmd === SCScout.syncEventIPAddr) {
             this.logSync('info', 'ScoutSyncManualAddressRequested') ;
             this.setView('sync-ipaddr') ;
-        }              
+        }
+        else if (cmd === SCScout.resetCurrentMatch) {
+            this.resetCurrentMatchCmd() ;
+        }
         else if (cmd === SCScout.resetTablet) {
             this.resetTabletCmd() ;
         }
@@ -437,6 +446,28 @@ export class SCScout extends SCBase {
         this.image_mgr_.removeAllImages() ;
     }
 
+    private resetCurrentMatchCmd() {
+        if (!this.current_scout_ || !this.current_scout_.startsWith('sm-')) {
+            dialog.showMessageBoxSync(this.win_, {
+                title: 'Reset Match Data',
+                type: 'warning',
+                message: 'No active match is selected to reset.',
+            }) ;
+            return ;
+        }
+
+        const matchItem = this.current_scout_ ;
+        this.deleteResults(matchItem) ;
+        this.writeEventFile() ;
+        this.logSync('info', 'ScoutCurrentMatchReset', {
+            item: matchItem,
+            remainingResults: this.info_.results_.length,
+        }) ;
+
+        this.sendToRenderer('send-nav-highlight', matchItem) ;
+        this.sendForm('match') ;
+    }
+
     private scoutTeam(team: string, force: boolean = false) {
         this.optionallyGetResults()
         .then(() => {
@@ -525,22 +556,69 @@ export class SCScout extends SCBase {
         let ret: IPCNamedDataValue[] = [] ;
 
         for(let r of res) {
-            if (r.value !== undefined) {
-                ret.push(r) ;
+            if (r && r.value !== undefined && r.value !== null) {
+                let value = (r as any).value ;
+                if (value.value !== undefined && value.value !== null) {
+                    ret.push(r) ;
+                }
             }
         }
 
         return ret ;
     }
 
-    public provideResults(res: IPCNamedDataValue[]) {
+    private isValidScoutItemId(item: string | undefined) : item is string {
+        if (!item || item.trim().length === 0) {
+            return false ;
+        }
+
+        if (/^st-\d+$/.test(item)) {
+            return true ;
+        }
+
+        const match = /^sm-([^-]+)-(\d+)-(\d+)-(\d+)$/.exec(item) ;
+        if (!match) {
+            return false ;
+        }
+
+        const level = match[1] ;
+        if (!['qm', 'sf', 'f'].includes(level)) {
+            return false ;
+        }
+
+        return Number(match[2]) > 0 && Number(match[3]) > 0 && Number(match[4]) > 0 ;
+    }
+
+    public provideResults(res: IPCNamedDataValue[], scoutItem?: string) {
+        const effectiveScoutItem = scoutItem ?? this.current_scout_ ;
         this.logSync('debug', 'ScoutProvideResults', {
             currentScout: this.current_scout_,
+            requestedScoutItem: scoutItem,
+            effectiveScoutItem: effectiveScoutItem,
             resultCount: res.length,
         }) ;
-        this.addResults(this.current_scout_!, this.filterResults(res)) ;
+
+        if (!this.isValidScoutItemId(effectiveScoutItem)) {
+            this.logSync('warn', 'ScoutProvideResultsDropped', {
+                reason: 'invalid-current-scout-item',
+                currentScout: this.current_scout_,
+                requestedScoutItem: scoutItem,
+            }) ;
+            this.sendToRenderer('set-status-title', 'Invalid Local Scout State') ;
+            this.sendToRenderer('set-status-visible', true) ;
+            this.sendToRenderer('set-status-text', 'Cannot save scouting results because no valid scout item is active. Please reopen the item and try again.') ;
+            this.sendToRenderer('set-status-close-button-visible', true) ;
+
+            if (this.resultPromiseResolve_) {
+                this.resultPromiseResolve_() ;
+                this.resultPromiseResolve_ = undefined ;
+            }
+            return ;
+        }
+
+        this.addResults(effectiveScoutItem, this.filterResults(res)) ;
         this.writeEventFile() ;
-        this.logger_.silly('provideResults:' + this.current_scout_, res) ;
+        this.logger_.silly('provideResults:' + effectiveScoutItem, res) ;
 
         if (this.resultPromiseResolve_) {
             // If there is a promise waiting for results, resolve it now.
@@ -650,6 +728,14 @@ export class SCScout extends SCBase {
     }
     
     private addResults(scout: string, result: IPCNamedDataValue[]) {
+        if (!this.isValidScoutItemId(scout)) {
+            this.logSync('warn', 'ScoutAddResultsDropped', {
+                reason: 'invalid-scout-item-id',
+                scout: scout,
+            }) ;
+            return ;
+        }
+
         let resobj : IPCScoutResult = {
             item: scout,
             data: this.cloneNamedDataValues(result) ?? []
@@ -668,7 +754,7 @@ export class SCScout extends SCBase {
     private getCurrentResults() : Promise<void> {
         let ret = new Promise<void>((resolve, reject) => {
             this.resultPromiseResolve_ = resolve ;
-            this.sendToRenderer('request-results') ;
+            this.sendToRenderer('request-results', { scoutItem: this.current_scout_ }) ;
         }) ;
         return ret;
     }
@@ -681,8 +767,50 @@ export class SCScout extends SCBase {
         } ;
     }
 
+    private findFirstResultIndexFromErrors(errors: string[]) : number | undefined {
+        for (let err of errors) {
+            let match = /results\[(\d+)\]/.exec(err) ;
+            if (match) {
+                return +match[1] ;
+            }
+        }
+
+        return undefined ;
+    }
+
+    private buildValidationDiagnosticDump(title: string, errors: string[]) : string | undefined {
+        if (title !== 'Invalid Local Sync Data') {
+            return undefined ;
+        }
+
+        let index = this.findFirstResultIndexFromErrors(errors) ;
+        let failingResult = undefined ;
+        if (index !== undefined && index >= 0 && index < this.info_.results_.length) {
+            failingResult = this.info_.results_[index] ;
+        }
+
+        let dump = {
+            title: title,
+            errors: errors,
+            currentScout: this.current_scout_ ?? null,
+            tablet: this.info_.tablet_,
+            purpose: this.info_.purpose_,
+            eventUuid: this.info_.uuid_,
+            resultsCount: this.info_.results_.length,
+            failingResultIndex: index,
+            failingResult: failingResult,
+        } ;
+
+        return JSON.stringify(dump, null, 2) ;
+    }
+
     private showSyncValidationError(title: string, errors: string[]) {
-        const message = summarizeValidationErrors(errors) ;
+        let message = summarizeValidationErrors(errors) ;
+        let dump = this.buildValidationDiagnosticDump(title, errors) ;
+        if (dump) {
+            message += '\n\nDiagnostic JSON (copy/paste):\n' + dump ;
+        }
+
         this.logSync('error', 'ScoutSyncValidationFailed', {
             title: title,
             errorCount: errors.length,
@@ -1336,6 +1464,13 @@ export class SCScout extends SCBase {
 
         ret.append(filemenu) ;
 
+        let editmenu: MenuItem = new MenuItem({
+            type: 'submenu',
+            role: 'editMenu',
+            label: 'Edit',
+        }) ;
+        ret.append(editmenu) ;
+
         let resetmenu: MenuItem = new MenuItem({
             type: 'submenu',
             label: 'Reset',
@@ -1344,10 +1479,17 @@ export class SCScout extends SCBase {
 
         let resetitem: MenuItem = new MenuItem( {
             type: 'normal',
+            label: 'Reset Current Match',
+            click: () => { this.executeCommand(SCScout.resetCurrentMatch)}
+        }) ;
+        resetmenu.submenu?.insert(0, resetitem) ;
+
+        resetitem = new MenuItem( {
+            type: 'normal',
             label: 'Reset Tablet',
             click: () => { this.executeCommand(SCScout.resetTablet)}
         }) ;
-        resetmenu.submenu?.insert(0, resetitem) ;
+        resetmenu.submenu?.insert(1, resetitem) ;
         ret.append(resetmenu);    
 
         let optionmenu: MenuItem = new MenuItem({

--- a/main/src/main/ipchandlers.ts
+++ b/main/src/main/ipchandlers.ts
@@ -637,13 +637,22 @@ export async function setTabletNamePurpose(cmd: string, ...args: any[]) {
     } 
 }
 
-// provide-result data:object[]
+// provide-result data:object[] | { scoutItem?: string, data: object[] }
 export async function provideResult(cmd: string, ...args: any[]) {
     if (scappbase && isScoutType()) {
         scappbase.logger_.silly({ message: 'renderer -> main', args: {cmd: cmd, cmdargs: args}});
         let scout : SCScout = scappbase as SCScout ;
         if (args.length === 1 && typeof args[0] === 'object') {
-            scout.provideResults(args[0] as IPCNamedDataValue[]) ;
+            const payload = args[0] ;
+            if (Array.isArray(payload)) {
+                scout.provideResults(payload as IPCNamedDataValue[]) ;
+            }
+            else if (Array.isArray(payload.data)) {
+                scout.provideResults(payload.data as IPCNamedDataValue[], payload.scoutItem as string | undefined) ;
+            }
+            else {
+                scappbase.logger_.error({ message: 'renderer -> main invalid args', args: {cmd: cmd, cmdargs: args}});
+            }
         }
         else {
             scappbase.logger_.error({ message: 'renderer -> main invalid args', args: {cmd: cmd, cmdargs: args}});             

--- a/main/src/shared/synccontract.ts
+++ b/main/src/shared/synccontract.ts
@@ -51,6 +51,22 @@ function addError(errors: string[], path: string, message: string) {
     errors.push(`${path} ${message}`);
 }
 
+function summarizeScoutResultTags(value: unknown): string {
+    if (!isObject(value) || !Array.isArray(value.data)) {
+        return "";
+    }
+
+    const tags = value.data
+        .filter((entry) => isObject(entry) && typeof entry.tag === "string" && entry.tag.trim().length > 0)
+        .map((entry) => (entry as Record<string, unknown>).tag as string);
+
+    if (tags.length === 0) {
+        return "";
+    }
+
+    return `; data tags: ${tags.join(", ")}`;
+}
+
 function requireStrictObject(value: unknown, path: string, errors: string[], keys: string[]): value is Record<string, unknown> {
     if (!isObject(value)) {
         addError(errors, path, `expected object but got ${describeValue(value)}`);
@@ -232,7 +248,10 @@ function validateScoutResult(value: unknown, path: string, errors: string[]): va
 
     const obj = value as Record<string, unknown>;
     let ok = true;
-    ok = requireString(obj.item, `${path}.item`, errors) && ok;
+    if (!requireString(obj.item, `${path}.item`, errors)) {
+        addError(errors, path, `is missing scout item id${summarizeScoutResultTags(value)}`);
+        ok = false;
+    }
     if (typeof obj.item === "string") {
         validateScoutItemId(obj.item, `${path}.item`, errors);
     }

--- a/main/src/shared/synccontract.ts
+++ b/main/src/shared/synccontract.ts
@@ -1,0 +1,1382 @@
+import {
+    IPCChoice,
+    IPCColumnDesc,
+    IPCDataItem,
+    IPCDataSet,
+    IPCForm,
+    IPCFormControlType,
+    IPCFormItem,
+    IPCFormula,
+    IPCGraphConfig,
+    IPCNamedDataValue,
+    IPCPickListConfig,
+    IPCPlayoffStatus,
+    IPCScoutResult,
+    IPCScoutResults,
+    IPCSection,
+    IPCSyncedImageData,
+    IPCTabletDefn,
+    IPCTypedDataValue,
+} from "./ipc";
+import { BAEvent, BAMatch, BATeam } from "../main/extnet/badata";
+
+type Validator<T> = (value: unknown, path: string, errors: string[]) => boolean;
+
+export interface ValidationSuccess<T> {
+    ok: true;
+    value: T;
+}
+
+export interface ValidationFailure {
+    ok: false;
+    errors: string[];
+}
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+const appTypes = new Set(["central", "scout", "coach"]);
+const purposes = new Set(["team", "match"]);
+const typedValueTypes = new Set(["integer", "real", "string", "boolean", "array", "null", "error"]);
+const imageExtensions = new Set(["png", "webp"]);
+const controlTypes = new Set(["label", "text", "textarea", "boolean", "updown", "choice", "select", "timer", "stopwatch", "box", "image", "autoplan", "autoselector", "robotphoto", "robotviewer"]);
+const matchLevels = new Set(["qm", "sf", "f"]);
+const playoffAlliances = new Set(["red", "blue"]);
+const graphTypes = new Set(["line", "bar", "scatter", "area"]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function addError(errors: string[], path: string, message: string) {
+    errors.push(`${path} ${message}`);
+}
+
+function requireStrictObject(value: unknown, path: string, errors: string[], keys: string[]): value is Record<string, unknown> {
+    if (!isObject(value)) {
+        addError(errors, path, `expected object but got ${describeValue(value)}`);
+        return false;
+    }
+
+    const allowed = new Set(keys);
+    for (const key of Object.keys(value)) {
+        if (!allowed.has(key)) {
+            addError(errors, path, `contains unknown key '${key}'`);
+        }
+    }
+
+    return true;
+}
+
+function describeValue(value: unknown): string {
+    if (value === null) {
+        return "null";
+    }
+    if (Array.isArray(value)) {
+        return "array";
+    }
+    return typeof value;
+}
+
+function requireString(value: unknown, path: string, errors: string[], opts?: { allowEmpty?: boolean }): value is string {
+    if (typeof value !== "string") {
+        addError(errors, path, `expected string but got ${describeValue(value)}`);
+        return false;
+    }
+    if (!opts?.allowEmpty && value.trim().length === 0) {
+        addError(errors, path, "must be a non-empty string");
+        return false;
+    }
+    return true;
+}
+
+function requireBoolean(value: unknown, path: string, errors: string[]): value is boolean {
+    if (typeof value !== "boolean") {
+        addError(errors, path, `expected boolean but got ${describeValue(value)}`);
+        return false;
+    }
+    return true;
+}
+
+function requireFiniteNumber(value: unknown, path: string, errors: string[], opts?: { integer?: boolean }): value is number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        addError(errors, path, `expected finite number but got ${describeValue(value)}`);
+        return false;
+    }
+    if (opts?.integer && !Number.isInteger(value)) {
+        addError(errors, path, "must be an integer");
+        return false;
+    }
+    return true;
+}
+
+function requireArray(value: unknown, path: string, errors: string[]): value is unknown[] {
+    if (!Array.isArray(value)) {
+        addError(errors, path, `expected array but got ${describeValue(value)}`);
+        return false;
+    }
+    return true;
+}
+
+function requireEnum(value: unknown, path: string, errors: string[], values: Set<string>): value is string {
+    if (!requireString(value, path, errors)) {
+        return false;
+    }
+    if (!values.has(value)) {
+        addError(errors, path, `must be one of ${[...values].join(", ")}`);
+        return false;
+    }
+    return true;
+}
+
+function validateChoice(value: unknown, path: string, errors: string[]): value is IPCChoice {
+    if (!requireStrictObject(value, path, errors, ["text", "value"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.text, `${path}.text`, errors) && ok;
+    if (typeof obj.value !== "string" && !(typeof obj.value === "number" && Number.isFinite(obj.value))) {
+        addError(errors, `${path}.value`, `expected string or finite number but got ${describeValue(obj.value)}`);
+        ok = false;
+    }
+    return ok;
+}
+
+function validateTypedValue(value: unknown, path: string, errors: string[]): value is IPCTypedDataValue {
+    if (!requireStrictObject(value, path, errors, ["type", "value"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = requireEnum(obj.type, `${path}.type`, errors, typedValueTypes);
+    if (!ok) {
+        return false;
+    }
+
+    switch (obj.type) {
+        case "integer":
+            ok = requireFiniteNumber(obj.value, `${path}.value`, errors, { integer: true }) && ok;
+            break;
+        case "real":
+            ok = requireFiniteNumber(obj.value, `${path}.value`, errors) && ok;
+            break;
+        case "string":
+            ok = typeof obj.value === "string" && ok;
+            if (typeof obj.value !== "string") {
+                addError(errors, `${path}.value`, `expected string but got ${describeValue(obj.value)}`);
+            }
+            break;
+        case "boolean":
+            ok = requireBoolean(obj.value, `${path}.value`, errors) && ok;
+            break;
+        case "array":
+            ok = requireArray(obj.value, `${path}.value`, errors) && ok;
+            break;
+        case "null":
+            if (obj.value !== null) {
+                addError(errors, `${path}.value`, `expected null but got ${describeValue(obj.value)}`);
+                ok = false;
+            }
+            break;
+        case "error":
+            ok = requireString(obj.value, `${path}.value`, errors, { allowEmpty: true }) && ok;
+            break;
+    }
+
+    return ok;
+}
+
+function validateNamedDataValue(value: unknown, path: string, errors: string[]): value is IPCNamedDataValue {
+    if (!requireStrictObject(value, path, errors, ["tag", "value"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.tag, `${path}.tag`, errors) && ok;
+    ok = validateTypedValue(obj.value, `${path}.value`, errors) && ok;
+    return ok;
+}
+
+function validateScoutItemId(value: string, path: string, errors: string[]) {
+    if (value.startsWith("st-")) {
+        const number = value.substring(3);
+        if (!/^\d+$/.test(number) || Number(number) <= 0) {
+            addError(errors, path, "must be a valid team item id like st-254");
+        }
+        return;
+    }
+
+    const match = /^sm-([^-]+)-(\d+)-(\d+)-(\d+)$/.exec(value);
+    if (!match) {
+        addError(errors, path, "must be a valid scout item id like st-254 or sm-qm-1-12-254");
+        return;
+    }
+
+    if (!matchLevels.has(match[1])) {
+        addError(errors, path, `has unsupported match level '${match[1]}'`);
+    }
+    for (let i = 2; i <= 4; i++) {
+        if (Number(match[i]) <= 0) {
+            addError(errors, path, "must use positive numeric segments");
+            break;
+        }
+    }
+}
+
+function validateScoutResult(value: unknown, path: string, errors: string[]): value is IPCScoutResult {
+    if (!requireStrictObject(value, path, errors, ["item", "data"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.item, `${path}.item`, errors) && ok;
+    if (typeof obj.item === "string") {
+        validateScoutItemId(obj.item, `${path}.item`, errors);
+    }
+
+    if (!requireArray(obj.data, `${path}.data`, errors)) {
+        return false;
+    }
+
+    const seenTags = new Set<string>();
+    obj.data.forEach((entry, index) => {
+        ok = validateNamedDataValue(entry, `${path}.data[${index}]`, errors) && ok;
+        if (isObject(entry) && typeof entry.tag === "string") {
+            if (seenTags.has(entry.tag)) {
+                addError(errors, `${path}.data[${index}].tag`, `duplicates tag '${entry.tag}' in the same result`);
+                ok = false;
+            }
+            seenTags.add(entry.tag);
+        }
+    });
+
+    return ok;
+}
+
+function validateScoutResults(value: unknown, path: string, errors: string[]): value is IPCScoutResults {
+    if (!requireStrictObject(value, path, errors, ["tablet", "purpose", "results"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.tablet, `${path}.tablet`, errors) && ok;
+    ok = requireEnum(obj.purpose, `${path}.purpose`, errors, purposes) && ok;
+    if (!requireArray(obj.results, `${path}.results`, errors)) {
+        return false;
+    }
+
+    const seenItems = new Set<string>();
+    obj.results.forEach((entry, index) => {
+        ok = validateScoutResult(entry, `${path}.results[${index}]`, errors) && ok;
+        if (isObject(entry) && typeof entry.item === "string") {
+            if (seenItems.has(entry.item)) {
+                addError(errors, `${path}.results[${index}].item`, `duplicates item '${entry.item}' in the same payload`);
+                ok = false;
+            }
+            seenItems.add(entry.item);
+        }
+    });
+
+    return ok;
+}
+
+function validateScoutHello(value: unknown, path: string, errors: string[]): value is { name: string; purpose: string } {
+    if (!requireStrictObject(value, path, errors, ["name", "purpose"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireEnum(obj.purpose, `${path}.purpose`, errors, purposes) && ok;
+    return ok;
+}
+
+function validateHelloResponse(value: unknown, path: string, errors: string[]): value is { uuid?: string; name: string } {
+    if (!requireStrictObject(value, path, errors, ["uuid", "name"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    if (obj.uuid !== undefined) {
+        ok = requireString(obj.uuid, `${path}.uuid`, errors) && ok;
+    }
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    return ok;
+}
+
+function validateTabletDefn(value: unknown, path: string, errors: string[]): value is IPCTabletDefn {
+    if (!requireStrictObject(value, path, errors, ["name", "purpose"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    if (obj.purpose !== undefined) {
+        ok = requireEnum(obj.purpose, `${path}.purpose`, errors, purposes) && ok;
+    }
+    return ok;
+}
+
+function validateStringArray(value: unknown, path: string, errors: string[], opts?: { nonEmpty?: boolean; unique?: boolean }): value is string[] {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    const seen = new Set<string>();
+    value.forEach((entry, index) => {
+        ok = requireString(entry, `${path}[${index}]`, errors, { allowEmpty: !opts?.nonEmpty }) && ok;
+        if (typeof entry === "string") {
+            if (opts?.unique && seen.has(entry)) {
+                addError(errors, `${path}[${index}]`, `duplicates value '${entry}'`);
+                ok = false;
+            }
+            seen.add(entry);
+        }
+    });
+    return ok;
+}
+
+function validateImageData(value: unknown, path: string, errors: string[]): value is IPCSyncedImageData {
+    if (!requireStrictObject(value, path, errors, ["data", "mimeType", "extension"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.data, `${path}.data`, errors) && ok;
+    ok = requireString(obj.mimeType, `${path}.mimeType`, errors) && ok;
+    ok = requireEnum(obj.extension, `${path}.extension`, errors, imageExtensions) && ok;
+    return ok;
+}
+
+function validateImagePayloadMap(value: unknown, path: string, errors: string[]): value is Record<string, IPCSyncedImageData> {
+    if (!isObject(value)) {
+        addError(errors, path, `expected object but got ${describeValue(value)}`);
+        return false;
+    }
+    let ok = true;
+    for (const key of Object.keys(value)) {
+        ok = requireString(key, `${path}.{key}`, errors) && ok;
+        if (key.trim().length === 0) {
+            addError(errors, `${path}.{key}`, "must be a non-empty image name");
+            ok = false;
+        }
+        ok = validateImageData(value[key], `${path}.${key}`, errors) && ok;
+    }
+    return ok;
+}
+
+function validateDataItem(value: unknown, path: string, errors: string[]): value is IPCDataItem {
+    if (!requireStrictObject(value, path, errors, ["label", "name", "dataset", "decimals", "width"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.label, `${path}.label`, errors) && ok;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireString(obj.dataset, `${path}.dataset`, errors, { allowEmpty: true }) && ok;
+    if (obj.decimals !== undefined) {
+        ok = requireFiniteNumber(obj.decimals, `${path}.decimals`, errors, { integer: true }) && ok;
+    }
+    if (obj.width !== undefined) {
+        ok = requireFiniteNumber(obj.width, `${path}.width`, errors) && ok;
+    }
+    return ok;
+}
+
+function validateGraphConfig(value: unknown, path: string, errors: string[]): value is IPCGraphConfig {
+    if (!requireStrictObject(value, path, errors, ["name", "xlabel", "yleft", "yright", "title", "type", "teams", "leftitems", "rightitems", "owner"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireString(obj.xlabel, `${path}.xlabel`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.yleft, `${path}.yleft`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.yright, `${path}.yright`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.title, `${path}.title`, errors) && ok;
+    ok = requireString(obj.type, `${path}.type`, errors) && ok;
+    if (typeof obj.type === "string" && obj.type.trim().length > 0 && !graphTypes.has(obj.type)) {
+        // keep permissive enough for existing saved configs but still reject blank/invalid primitives
+    }
+    ok = requireEnum(obj.owner, `${path}.owner`, errors, appTypes) && ok;
+    if (!requireArray(obj.teams, `${path}.teams`, errors)) {
+        return false;
+    }
+    obj.teams.forEach((entry, index) => {
+        ok = requireFiniteNumber(entry, `${path}.teams[${index}]`, errors, { integer: true }) && ok;
+    });
+    if (!requireArray(obj.leftitems, `${path}.leftitems`, errors) || !requireArray(obj.rightitems, `${path}.rightitems`, errors)) {
+        return false;
+    }
+    obj.leftitems.forEach((entry, index) => {
+        ok = validateDataItem(entry, `${path}.leftitems[${index}]`, errors) && ok;
+    });
+    obj.rightitems.forEach((entry, index) => {
+        ok = validateDataItem(entry, `${path}.rightitems[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validatePicklistConfig(value: unknown, path: string, errors: string[]): value is IPCPickListConfig {
+    if (!requireStrictObject(value, path, errors, ["name", "teams", "columns", "notes", "cellColors", "columnGradients", "positionWidth", "teamWidth", "nicknameWidth", "notesWidth", "owner"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireEnum(obj.owner, `${path}.owner`, errors, appTypes) && ok;
+    if (!requireArray(obj.teams, `${path}.teams`, errors)) {
+        return false;
+    }
+    obj.teams.forEach((entry, index) => {
+        ok = requireFiniteNumber(entry, `${path}.teams[${index}]`, errors, { integer: true }) && ok;
+    });
+    if (!requireArray(obj.columns, `${path}.columns`, errors) || !requireArray(obj.notes, `${path}.notes`, errors)) {
+        return false;
+    }
+    obj.columns.forEach((entry, index) => {
+        ok = validateDataItem(entry, `${path}.columns[${index}]`, errors) && ok;
+    });
+    obj.notes.forEach((entry, index) => {
+        ok = requireString(entry, `${path}.notes[${index}]`, errors, { allowEmpty: true }) && ok;
+    });
+    if (obj.notes.length !== obj.teams.length) {
+        addError(errors, `${path}.notes`, `must match teams length ${obj.teams.length}`);
+        ok = false;
+    }
+    return ok;
+}
+
+function validateColumnDesc(value: unknown, path: string, errors: string[]): value is IPCColumnDesc {
+    if (!requireStrictObject(value, path, errors, ["name", "type", "source", "editable", "hiddenByDefault", "choices"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireEnum(obj.type, `${path}.type`, errors, typedValueTypes) && ok;
+    ok = requireEnum(obj.source, `${path}.source`, errors, new Set(["form", "bluealliance", "base", "statbotics"])) && ok;
+    ok = requireBoolean(obj.editable, `${path}.editable`, errors) && ok;
+    if (obj.hiddenByDefault !== undefined) {
+        ok = requireBoolean(obj.hiddenByDefault, `${path}.hiddenByDefault`, errors) && ok;
+    }
+    if (obj.choices !== undefined) {
+        if (!requireArray(obj.choices, `${path}.choices`, errors)) {
+            ok = false;
+        }
+        else {
+            obj.choices.forEach((entry, index) => {
+                ok = validateChoice(entry, `${path}.choices[${index}]`, errors) && ok;
+            });
+        }
+    }
+    return ok;
+}
+
+function validateFormItem(value: unknown, path: string, errors: string[]): value is IPCFormItem {
+    const baseKeys = ["type", "tag", "x", "y", "width", "height", "fontFamily", "fontSize", "fontStyle", "fontWeight", "color", "background", "transparent", "datatype", "locked"];
+    if (!isObject(value)) {
+        addError(errors, path, `expected object but got ${describeValue(value)}`);
+        return false;
+    }
+
+    const type = (value as Record<string, unknown>).type;
+    if (!requireEnum(type, `${path}.type`, errors, controlTypes)) {
+        return false;
+    }
+
+    const extraKeys: Record<IPCFormControlType, string[]> = {
+        label: ["text"],
+        text: ["placeholder"],
+        textarea: ["rows", "cols"],
+        boolean: ["accent"],
+        updown: ["orientation", "minvalue", "maxvalue"],
+        choice: ["choices", "radiosize", "orientation", "multiselect"],
+        select: ["choices"],
+        timer: [],
+        stopwatch: ["holdMode"],
+        box: ["borderStyle", "borderWidth", "borderRadius", "borderShadow"],
+        image: ["image", "field", "mirrorx", "mirrory"],
+        autoplan: ["fieldImage", "approvedActions", "allowMultipleAutos"],
+        autoselector: ["fieldImage", "showSourceTagInTab"],
+        robotphoto: ["mode"],
+        robotviewer: [],
+    };
+
+    if (!requireStrictObject(value, path, errors, [...baseKeys, ...extraKeys[type as IPCFormControlType]])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.tag, `${path}.tag`, errors, { allowEmpty: true }) && ok;
+    ok = requireFiniteNumber(obj.x, `${path}.x`, errors) && ok;
+    ok = requireFiniteNumber(obj.y, `${path}.y`, errors) && ok;
+    ok = requireFiniteNumber(obj.width, `${path}.width`, errors) && ok;
+    ok = requireFiniteNumber(obj.height, `${path}.height`, errors) && ok;
+    ok = requireString(obj.fontFamily, `${path}.fontFamily`, errors, { allowEmpty: true }) && ok;
+    ok = requireFiniteNumber(obj.fontSize, `${path}.fontSize`, errors) && ok;
+    ok = requireString(obj.fontStyle, `${path}.fontStyle`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.fontWeight, `${path}.fontWeight`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.color, `${path}.color`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.background, `${path}.background`, errors, { allowEmpty: true }) && ok;
+    ok = requireBoolean(obj.transparent, `${path}.transparent`, errors) && ok;
+    ok = requireEnum(obj.datatype, `${path}.datatype`, errors, typedValueTypes) && ok;
+    if (obj.locked !== undefined) {
+        ok = requireBoolean(obj.locked, `${path}.locked`, errors) && ok;
+    }
+
+    switch (type) {
+        case "label":
+            ok = requireString(obj.text, `${path}.text`, errors, { allowEmpty: true }) && ok;
+            break;
+        case "text":
+            ok = requireString(obj.placeholder, `${path}.placeholder`, errors, { allowEmpty: true }) && ok;
+            break;
+        case "textarea":
+            ok = requireFiniteNumber(obj.rows, `${path}.rows`, errors, { integer: true }) && ok;
+            ok = requireFiniteNumber(obj.cols, `${path}.cols`, errors, { integer: true }) && ok;
+            break;
+        case "boolean":
+            ok = requireString(obj.accent, `${path}.accent`, errors, { allowEmpty: true }) && ok;
+            break;
+        case "updown":
+            ok = requireEnum(obj.orientation, `${path}.orientation`, errors, new Set(["horizontal", "vertical"])) && ok;
+            ok = requireFiniteNumber(obj.minvalue, `${path}.minvalue`, errors) && ok;
+            ok = requireFiniteNumber(obj.maxvalue, `${path}.maxvalue`, errors) && ok;
+            break;
+        case "choice":
+        case "select":
+            if (!requireArray(obj.choices, `${path}.choices`, errors)) {
+                ok = false;
+            }
+            else {
+                obj.choices.forEach((entry, index) => {
+                    ok = validateChoice(entry, `${path}.choices[${index}]`, errors) && ok;
+                });
+            }
+            if (type === "choice") {
+                ok = requireFiniteNumber(obj.radiosize, `${path}.radiosize`, errors) && ok;
+                ok = requireEnum(obj.orientation, `${path}.orientation`, errors, new Set(["horizontal", "vertical"])) && ok;
+                if (obj.multiselect !== undefined) {
+                    ok = requireBoolean(obj.multiselect, `${path}.multiselect`, errors) && ok;
+                }
+            }
+            break;
+        case "stopwatch":
+            if (obj.holdMode !== undefined) {
+                ok = requireBoolean(obj.holdMode, `${path}.holdMode`, errors) && ok;
+            }
+            break;
+        case "box":
+            ok = requireString(obj.borderStyle, `${path}.borderStyle`, errors, { allowEmpty: true }) && ok;
+            ok = requireFiniteNumber(obj.borderWidth, `${path}.borderWidth`, errors) && ok;
+            ok = requireFiniteNumber(obj.borderRadius, `${path}.borderRadius`, errors) && ok;
+            ok = requireBoolean(obj.borderShadow, `${path}.borderShadow`, errors) && ok;
+            break;
+        case "image":
+            ok = requireString(obj.image, `${path}.image`, errors) && ok;
+            ok = requireBoolean(obj.field, `${path}.field`, errors) && ok;
+            ok = requireBoolean(obj.mirrorx, `${path}.mirrorx`, errors) && ok;
+            ok = requireBoolean(obj.mirrory, `${path}.mirrory`, errors) && ok;
+            break;
+        case "autoplan":
+            ok = requireString(obj.fieldImage, `${path}.fieldImage`, errors) && ok;
+            ok = validateStringArray(obj.approvedActions, `${path}.approvedActions`, errors, { nonEmpty: true }) && ok;
+            ok = requireBoolean(obj.allowMultipleAutos, `${path}.allowMultipleAutos`, errors) && ok;
+            break;
+        case "autoselector":
+            ok = requireString(obj.fieldImage, `${path}.fieldImage`, errors) && ok;
+            if (obj.showSourceTagInTab !== undefined) {
+                ok = requireBoolean(obj.showSourceTagInTab, `${path}.showSourceTagInTab`, errors) && ok;
+            }
+            break;
+        case "robotphoto":
+            ok = requireEnum(obj.mode, `${path}.mode`, errors, new Set(["capture", "display"])) && ok;
+            break;
+    }
+
+    return ok;
+}
+
+function validateSection(value: unknown, path: string, errors: string[]): value is IPCSection {
+    if (!requireStrictObject(value, path, errors, ["name", "items"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors, { allowEmpty: true }) && ok;
+    if (!requireArray(obj.items, `${path}.items`, errors)) {
+        return false;
+    }
+    obj.items.forEach((entry, index) => {
+        ok = validateFormItem(entry, `${path}.items[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateForm(value: unknown, path: string, errors: string[]): value is IPCForm {
+    if (!requireStrictObject(value, path, errors, ["purpose", "tablet", "sections"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireEnum(obj.purpose, `${path}.purpose`, errors, purposes) && ok;
+    if (!requireStrictObject(obj.tablet, `${path}.tablet`, errors, ["name", "size"])) {
+        return false;
+    }
+    const tablet = obj.tablet as Record<string, unknown>;
+    ok = requireString(tablet.name, `${path}.tablet.name`, errors) && ok;
+    if (!requireStrictObject(tablet.size, `${path}.tablet.size`, errors, ["width", "height"])) {
+        return false;
+    }
+    ok = requireFiniteNumber((tablet.size as Record<string, unknown>).width, `${path}.tablet.size.width`, errors) && ok;
+    ok = requireFiniteNumber((tablet.size as Record<string, unknown>).height, `${path}.tablet.size.height`, errors) && ok;
+    if (!requireArray(obj.sections, `${path}.sections`, errors)) {
+        return false;
+    }
+    obj.sections.forEach((entry, index) => {
+        ok = validateSection(entry, `${path}.sections[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateTeamTablet(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["team", "tablet", "name"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireFiniteNumber(obj.team, `${path}.team`, errors, { integer: true }) && ok;
+    ok = requireString(obj.tablet, `${path}.tablet`, errors) && ok;
+    ok = requireString(obj.name, `${path}.name`, errors, { allowEmpty: true }) && ok;
+    return ok;
+}
+
+function validateMatchTablet(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["comp_level", "match_number", "set_number", "teamnumber", "teamname", "tablet", "alliance"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireEnum(obj.comp_level, `${path}.comp_level`, errors, matchLevels) && ok;
+    ok = requireFiniteNumber(obj.match_number, `${path}.match_number`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.set_number, `${path}.set_number`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.teamnumber, `${path}.teamnumber`, errors, { integer: true }) && ok;
+    ok = requireString(obj.teamname, `${path}.teamname`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.tablet, `${path}.tablet`, errors) && ok;
+    ok = requireEnum(obj.alliance, `${path}.alliance`, errors, playoffAlliances) && ok;
+    return ok;
+}
+
+function validatePlayoffAssignment(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["match", "tablet", "alliance", "which"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireFiniteNumber(obj.match, `${path}.match`, errors, { integer: true }) && ok;
+    ok = requireString(obj.tablet, `${path}.tablet`, errors) && ok;
+    ok = requireEnum(obj.alliance, `${path}.alliance`, errors, playoffAlliances) && ok;
+    ok = requireFiniteNumber(obj.which, `${path}.which`, errors, { integer: true }) && ok;
+    return ok;
+}
+
+function validatePlayoffStatus(value: unknown, path: string, errors: string[]): value is IPCPlayoffStatus {
+    if (!requireStrictObject(value, path, errors, ["alliances", "outcomes"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    if (!requireArray(obj.alliances, `${path}.alliances`, errors)) {
+        return false;
+    }
+    if (obj.alliances.length !== 8) {
+        addError(errors, `${path}.alliances`, "must contain exactly 8 alliance slots");
+        ok = false;
+    }
+    obj.alliances.forEach((entry, index) => {
+        if (entry === undefined || entry === null) {
+            return;
+        }
+        if (!requireStrictObject(entry, `${path}.alliances[${index}]`, errors, ["teams"])) {
+            ok = false;
+            return;
+        }
+        const teamObj = entry as Record<string, unknown>;
+        if (!requireArray(teamObj.teams, `${path}.alliances[${index}].teams`, errors) || teamObj.teams.length !== 3) {
+            ok = false;
+            return;
+        }
+        teamObj.teams.forEach((team, teamIndex) => {
+            ok = requireFiniteNumber(team, `${path}.alliances[${index}].teams[${teamIndex}]`, errors, { integer: true }) && ok;
+        });
+    });
+    if (!requireStrictObject(obj.outcomes, `${path}.outcomes`, errors, ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10", "m11", "m12", "m13", "m14", "m15", "m16"])) {
+        return false;
+    }
+    for (let i = 1; i <= 16; i++) {
+        const key = `m${i}`;
+        const entry = (obj.outcomes as Record<string, unknown>)[key];
+        if (entry === undefined || entry === null) {
+            continue;
+        }
+        if (!requireStrictObject(entry, `${path}.outcomes.${key}`, errors, ["winner", "loser"])) {
+            ok = false;
+            continue;
+        }
+        ok = requireFiniteNumber((entry as Record<string, unknown>).winner, `${path}.outcomes.${key}.winner`, errors, { integer: true }) && ok;
+        ok = requireFiniteNumber((entry as Record<string, unknown>).loser, `${path}.outcomes.${key}.loser`, errors, { integer: true }) && ok;
+    }
+    return ok;
+}
+
+function validateBAEvent(value: unknown, path: string, errors: string[]): value is BAEvent {
+    if (!requireStrictObject(value, path, errors, ["key", "name", "event_code", "event_type", "district", "city", "state_prov", "country", "start_date", "end_date", "year", "short_name", "event_type_string", "week", "address", "postal_code", "gmaps_place_id", "gmaps_url", "lat", "lng", "location_name", "timezone", "website", "first_event_id", "first_event_code", "webcasts", "division_keys", "parent_event_key", "playoff_type", "playoff_type_string"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.key, `${path}.key`, errors) && ok;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireFiniteNumber(obj.event_type, `${path}.event_type`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.year, `${path}.year`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.week, `${path}.week`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.lat, `${path}.lat`, errors) && ok;
+    ok = requireFiniteNumber(obj.lng, `${path}.lng`, errors) && ok;
+    ok = requireFiniteNumber(obj.playoff_type, `${path}.playoff_type`, errors, { integer: true }) && ok;
+    ["event_code", "city", "state_prov", "country", "start_date", "end_date", "short_name", "event_type_string", "address", "postal_code", "gmaps_place_id", "gmaps_url", "location_name", "timezone", "website", "first_event_id", "first_event_code", "parent_event_key", "playoff_type_string"].forEach((key) => {
+        ok = requireString(obj[key], `${path}.${key}`, errors, { allowEmpty: true }) && ok;
+    });
+    if (!requireStrictObject(obj.district, `${path}.district`, errors, ["abbreviation", "display_name", "key", "year"])) {
+        ok = false;
+    }
+    else {
+        const district = obj.district as Record<string, unknown>;
+        ok = requireString(district.abbreviation, `${path}.district.abbreviation`, errors, { allowEmpty: true }) && ok;
+        ok = requireString(district.display_name, `${path}.district.display_name`, errors, { allowEmpty: true }) && ok;
+        ok = requireString(district.key, `${path}.district.key`, errors, { allowEmpty: true }) && ok;
+        ok = requireFiniteNumber(district.year, `${path}.district.year`, errors, { integer: true }) && ok;
+    }
+    if (!requireArray(obj.webcasts, `${path}.webcasts`, errors)) {
+        ok = false;
+    }
+    else {
+        obj.webcasts.forEach((entry, index) => {
+            if (!requireStrictObject(entry, `${path}.webcasts[${index}]`, errors, ["type", "channel", "date", "file"])) {
+                ok = false;
+                return;
+            }
+            const webcast = entry as Record<string, unknown>;
+            ok = requireString(webcast.type, `${path}.webcasts[${index}].type`, errors, { allowEmpty: true }) && ok;
+            ok = requireString(webcast.channel, `${path}.webcasts[${index}].channel`, errors, { allowEmpty: true }) && ok;
+            ok = requireString(webcast.date, `${path}.webcasts[${index}].date`, errors, { allowEmpty: true }) && ok;
+            ok = requireString(webcast.file, `${path}.webcasts[${index}].file`, errors, { allowEmpty: true }) && ok;
+        });
+    }
+    ok = validateStringArray(obj.division_keys, `${path}.division_keys`, errors, { unique: true }) && ok;
+    return ok;
+}
+
+function validateBATeam(value: unknown, path: string, errors: string[]): value is BATeam {
+    if (!requireStrictObject(value, path, errors, ["key", "team_number", "nickname", "name", "school_name", "city", "state_prov", "country", "address", "postal_code", "gmaps_place_id", "gmaps_url", "lat", "lng", "location_name", "website", "rookie_year"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.key, `${path}.key`, errors) && ok;
+    ok = requireFiniteNumber(obj.team_number, `${path}.team_number`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.lat, `${path}.lat`, errors) && ok;
+    ok = requireFiniteNumber(obj.lng, `${path}.lng`, errors) && ok;
+    ok = requireFiniteNumber(obj.rookie_year, `${path}.rookie_year`, errors, { integer: true }) && ok;
+    ["nickname", "name", "school_name", "city", "state_prov", "country", "address", "postal_code", "gmaps_place_id", "gmaps_url", "location_name", "website"].forEach((key) => {
+        ok = requireString(obj[key], `${path}.${key}`, errors, { allowEmpty: true }) && ok;
+    });
+    return ok;
+}
+
+function validateBAMatch(value: unknown, path: string, errors: string[]): value is BAMatch {
+    if (!requireStrictObject(value, path, errors, ["key", "comp_level", "set_number", "match_number", "alliances", "winning_alliance", "event_key", "time", "actual_time", "predicted_time", "post_result_time", "score_breakdown", "videos"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.key, `${path}.key`, errors) && ok;
+    ok = requireEnum(obj.comp_level, `${path}.comp_level`, errors, matchLevels) && ok;
+    ok = requireFiniteNumber(obj.set_number, `${path}.set_number`, errors, { integer: true }) && ok;
+    ok = requireFiniteNumber(obj.match_number, `${path}.match_number`, errors, { integer: true }) && ok;
+    if (!requireStrictObject(obj.alliances, `${path}.alliances`, errors, ["red", "blue"])) {
+        return false;
+    }
+    (["red", "blue"] as const).forEach((alliance) => {
+        const node = (obj.alliances as Record<string, unknown>)[alliance];
+        if (!requireStrictObject(node, `${path}.alliances.${alliance}`, errors, ["score", "team_keys", "surrogate_team_keys", "dq_team_keys"])) {
+            ok = false;
+            return;
+        }
+        const one = node as Record<string, unknown>;
+        if (one.score !== undefined) {
+            ok = requireFiniteNumber(one.score, `${path}.alliances.${alliance}.score`, errors, { integer: true }) && ok;
+        }
+        ok = validateStringArray(one.team_keys, `${path}.alliances.${alliance}.team_keys`, errors) && ok;
+        if (Array.isArray(one.team_keys) && one.team_keys.length !== 3) {
+            addError(errors, `${path}.alliances.${alliance}.team_keys`, "must contain exactly 3 team keys");
+            ok = false;
+        }
+        ["surrogate_team_keys", "dq_team_keys"].forEach((field) => {
+            const arr = one[field];
+            if (arr === undefined) {
+                return;
+            }
+            if (!requireArray(arr, `${path}.alliances.${alliance}.${field}`, errors)) {
+                ok = false;
+                return;
+            }
+            arr.forEach((entry, index) => {
+                if (typeof entry !== "string" && !(typeof entry === "number" && Number.isFinite(entry))) {
+                    addError(errors, `${path}.alliances.${alliance}.${field}[${index}]`, `expected string or finite number but got ${describeValue(entry)}`);
+                    ok = false;
+                }
+            });
+        });
+    });
+    ["winning_alliance", "event_key"].forEach((key) => {
+        if (obj[key] !== undefined) {
+            ok = requireString(obj[key], `${path}.${key}`, errors, { allowEmpty: true }) && ok;
+        }
+    });
+    ["time", "actual_time", "predicted_time", "post_result_time"].forEach((key) => {
+        if (obj[key] !== undefined) {
+            ok = requireFiniteNumber(obj[key], `${path}.${key}`, errors) && ok;
+        }
+    });
+    if (obj.videos !== undefined) {
+        if (!requireArray(obj.videos, `${path}.videos`, errors)) {
+            ok = false;
+        }
+        else {
+            obj.videos.forEach((entry, index) => {
+                if (!requireStrictObject(entry, `${path}.videos[${index}]`, errors, ["type", "key"])) {
+                    ok = false;
+                    return;
+                }
+                ok = requireString((entry as Record<string, unknown>).type, `${path}.videos[${index}].type`, errors) && ok;
+                ok = requireString((entry as Record<string, unknown>).key, `${path}.videos[${index}].key`, errors) && ok;
+            });
+        }
+    }
+    return ok;
+}
+
+function validateFormula(value: unknown, path: string, errors: string[]): value is IPCFormula {
+    if (!requireStrictObject(value, path, errors, ["name", "desc", "formula", "owner"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireString(obj.desc, `${path}.desc`, errors, { allowEmpty: true }) && ok;
+    ok = requireString(obj.formula, `${path}.formula`, errors, { allowEmpty: true }) && ok;
+    ok = requireEnum(obj.owner, `${path}.owner`, errors, appTypes) && ok;
+    return ok;
+}
+
+function validateDataSet(value: unknown, path: string, errors: string[]): value is IPCDataSet {
+    if (!requireStrictObject(value, path, errors, ["name", "matches", "formula"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireString(obj.name, `${path}.name`, errors) && ok;
+    ok = requireString(obj.formula, `${path}.formula`, errors, { allowEmpty: true }) && ok;
+    if (!requireStrictObject(obj.matches, `${path}.matches`, errors, ["kind", "first", "last", "comp_level", "match_number", "set_number"])) {
+        return false;
+    }
+    const matches = obj.matches as Record<string, unknown>;
+    ok = requireString(matches.kind, `${path}.matches.kind`, errors) && ok;
+    if (typeof matches.kind === "string") {
+        if (matches.kind === "specific") {
+            ok = requireEnum(matches.comp_level, `${path}.matches.comp_level`, errors, matchLevels) && ok;
+            ok = requireFiniteNumber(matches.match_number, `${path}.matches.match_number`, errors, { integer: true }) && ok;
+            ok = requireFiniteNumber(matches.set_number, `${path}.matches.set_number`, errors, { integer: true }) && ok;
+        }
+        else {
+            ok = requireFiniteNumber(matches.first, `${path}.matches.first`, errors, { integer: true }) && ok;
+            ok = requireFiniteNumber(matches.last, `${path}.matches.last`, errors, { integer: true }) && ok;
+        }
+    }
+    return ok;
+}
+
+function validateProjectInfo(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["frcev_", "uuid_", "name_", "locked_", "hidden_hints_", "data_info_", "dataset_info_", "picklist_info_", "team_info_", "formula_info_", "tablet_info_", "match_info_", "graph_info_", "form_info_", "team_db_info_", "match_db_info_", "playoff_info_"])) {
+        return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    if (obj.frcev_ !== undefined) {
+        ok = validateBAEvent(obj.frcev_, `${path}.frcev_`, errors) && ok;
+    }
+    if (obj.uuid_ !== undefined) {
+        ok = requireString(obj.uuid_, `${path}.uuid_`, errors) && ok;
+    }
+    if (obj.name_ !== undefined) {
+        ok = requireString(obj.name_, `${path}.name_`, errors, { allowEmpty: true }) && ok;
+    }
+    ok = requireBoolean(obj.locked_, `${path}.locked_`, errors) && ok;
+    ok = validateStringArray(obj.hidden_hints_, `${path}.hidden_hints_`, errors, { unique: true }) && ok;
+
+    if (!requireStrictObject(obj.data_info_, `${path}.data_info_`, errors, ["matchdb_col_config_", "teamdb_col_config_", "scouted_team_", "scouted_match_", "match_results_", "team_results_", "match_formulas_", "team_formulas_"])) {
+        return false;
+    }
+    const dataInfo = obj.data_info_ as Record<string, unknown>;
+    if (dataInfo.matchdb_col_config_ !== undefined) {
+        ok = validateColumnConfig(dataInfo.matchdb_col_config_, `${path}.data_info_.matchdb_col_config_`, errors) && ok;
+    }
+    if (dataInfo.teamdb_col_config_ !== undefined) {
+        ok = validateColumnConfig(dataInfo.teamdb_col_config_, `${path}.data_info_.teamdb_col_config_`, errors) && ok;
+    }
+    ok = validateNumberArray(dataInfo.scouted_team_, `${path}.data_info_.scouted_team_`, errors, { integer: true }) && ok;
+    ok = validateStringArray(dataInfo.scouted_match_, `${path}.data_info_.scouted_match_`, errors, { nonEmpty: true, unique: true }) && ok;
+    ok = validateScoutResultArray(dataInfo.match_results_, `${path}.data_info_.match_results_`, errors) && ok;
+    ok = validateScoutResultArray(dataInfo.team_results_, `${path}.data_info_.team_results_`, errors) && ok;
+    ok = validateFormulaCheckArray(dataInfo.match_formulas_, `${path}.data_info_.match_formulas_`, errors) && ok;
+    ok = validateFormulaCheckArray(dataInfo.team_formulas_, `${path}.data_info_.team_formulas_`, errors) && ok;
+
+    if (!requireStrictObject(obj.dataset_info_, `${path}.dataset_info_`, errors, ["datasets_"])) {
+        return false;
+    }
+    if (!requireArray((obj.dataset_info_ as Record<string, unknown>).datasets_, `${path}.dataset_info_.datasets_`, errors)) {
+        return false;
+    }
+    ((obj.dataset_info_ as Record<string, unknown>).datasets_ as unknown[]).forEach((entry, index) => {
+        ok = validateDataSet(entry, `${path}.dataset_info_.datasets_[${index}]`, errors) && ok;
+    });
+
+    if (!requireStrictObject(obj.picklist_info_, `${path}.picklist_info_`, errors, ["picklist_", "coaches_picklist_"])) {
+        return false;
+    }
+    ok = validatePicklistArray((obj.picklist_info_ as Record<string, unknown>).picklist_, `${path}.picklist_info_.picklist_`, errors) && ok;
+    ok = validatePicklistArray((obj.picklist_info_ as Record<string, unknown>).coaches_picklist_, `${path}.picklist_info_.coaches_picklist_`, errors) && ok;
+
+    if (!requireStrictObject(obj.team_info_, `${path}.team_info_`, errors, ["teams_"])) {
+        return false;
+    }
+    ok = validateBATeamArray((obj.team_info_ as Record<string, unknown>).teams_, `${path}.team_info_.teams_`, errors) && ok;
+
+    if (!requireStrictObject(obj.formula_info_, `${path}.formula_info_`, errors, ["formulas_", "coach_formulas_"])) {
+        return false;
+    }
+    ok = validateFormulaArray((obj.formula_info_ as Record<string, unknown>).formulas_, `${path}.formula_info_.formulas_`, errors) && ok;
+    ok = validateFormulaArray((obj.formula_info_ as Record<string, unknown>).coach_formulas_, `${path}.formula_info_.coach_formulas_`, errors) && ok;
+
+    if (!requireStrictObject(obj.tablet_info_, `${path}.tablet_info_`, errors, ["tablets_", "teamassignments_", "matchassignements_", "playoffassignments_"])) {
+        return false;
+    }
+    ok = validateTabletArray((obj.tablet_info_ as Record<string, unknown>).tablets_, `${path}.tablet_info_.tablets_`, errors) && ok;
+    ok = validateTeamAssignmentArray((obj.tablet_info_ as Record<string, unknown>).teamassignments_, `${path}.tablet_info_.teamassignments_`, errors) && ok;
+    ok = validateMatchAssignmentArray((obj.tablet_info_ as Record<string, unknown>).matchassignements_, `${path}.tablet_info_.matchassignements_`, errors) && ok;
+    ok = validatePlayoffAssignmentArray((obj.tablet_info_ as Record<string, unknown>).playoffassignments_, `${path}.tablet_info_.playoffassignments_`, errors) && ok;
+
+    if (!requireStrictObject(obj.match_info_, `${path}.match_info_`, errors, ["matches_"])) {
+        return false;
+    }
+    ok = validateBAMatchArray((obj.match_info_ as Record<string, unknown>).matches_, `${path}.match_info_.matches_`, errors) && ok;
+
+    if (!requireStrictObject(obj.graph_info_, `${path}.graph_info_`, errors, ["single_team_configs_", "coach_configs_", "match_sim_configs_", "auto_analysis_configs_"])) {
+        return false;
+    }
+    ok = validateGraphArray((obj.graph_info_ as Record<string, unknown>).single_team_configs_, `${path}.graph_info_.single_team_configs_`, errors) && ok;
+    ok = validateGraphArray((obj.graph_info_ as Record<string, unknown>).coach_configs_, `${path}.graph_info_.coach_configs_`, errors) && ok;
+    ok = validateLooseArray((obj.graph_info_ as Record<string, unknown>).match_sim_configs_, `${path}.graph_info_.match_sim_configs_`, errors) && ok;
+    ok = validateLooseArray((obj.graph_info_ as Record<string, unknown>).auto_analysis_configs_, `${path}.graph_info_.auto_analysis_configs_`, errors) && ok;
+
+    if (!requireStrictObject(obj.form_info_, `${path}.form_info_`, errors, ["teamform_", "matchform_"])) {
+        return false;
+    }
+    if ((obj.form_info_ as Record<string, unknown>).teamform_ !== undefined) {
+        ok = requireString((obj.form_info_ as Record<string, unknown>).teamform_, `${path}.form_info_.teamform_`, errors) && ok;
+    }
+    if ((obj.form_info_ as Record<string, unknown>).matchform_ !== undefined) {
+        ok = requireString((obj.form_info_ as Record<string, unknown>).matchform_, `${path}.form_info_.matchform_`, errors) && ok;
+    }
+
+    ok = validateModelInfo(obj.team_db_info_, `${path}.team_db_info_`, errors) && ok;
+    ok = validateModelInfo(obj.match_db_info_, `${path}.match_db_info_`, errors) && ok;
+    ok = validatePlayoffStatus(obj.playoff_info_, `${path}.playoff_info_`, errors) && ok;
+    return ok;
+}
+
+function validateColumnConfig(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["columns", "frozenColumnCount"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    let ok = true;
+    ok = requireFiniteNumber(obj.frozenColumnCount, `${path}.frozenColumnCount`, errors, { integer: true }) && ok;
+    if (!requireArray(obj.columns, `${path}.columns`, errors)) {
+        return false;
+    }
+    obj.columns.forEach((entry, index) => {
+        if (!requireStrictObject(entry, `${path}.columns[${index}]`, errors, ["name", "width", "hidden"])) {
+            ok = false;
+            return;
+        }
+        const col = entry as Record<string, unknown>;
+        ok = requireString(col.name, `${path}.columns[${index}].name`, errors) && ok;
+        ok = requireFiniteNumber(col.width, `${path}.columns[${index}].width`, errors, { integer: true }) && ok;
+        ok = requireBoolean(col.hidden, `${path}.columns[${index}].hidden`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateNumberArray(value: unknown, path: string, errors: string[], opts?: { integer?: boolean }): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = requireFiniteNumber(entry, `${path}[${index}]`, errors, { integer: opts?.integer }) && ok;
+    });
+    return ok;
+}
+
+function validateScoutResultArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateScoutResult(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateFormulaCheckArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        if (!requireStrictObject(entry, `${path}[${index}]`, errors, ["columns", "formula", "type", "message", "background", "color", "fontFamily", "fontSize", "fontStyle", "fontWeight"])) {
+            ok = false;
+            return;
+        }
+        const obj = entry as Record<string, unknown>;
+        ok = validateStringArray(obj.columns, `${path}[${index}].columns`, errors, { nonEmpty: true }) && ok;
+        ["formula", "type", "message", "background", "color", "fontFamily", "fontStyle", "fontWeight"].forEach((key) => {
+            ok = requireString(obj[key], `${path}[${index}].${key}`, errors, { allowEmpty: key !== "formula" }) && ok;
+        });
+        ok = requireFiniteNumber(obj.fontSize, `${path}[${index}].fontSize`, errors) && ok;
+    });
+    return ok;
+}
+
+function validatePicklistArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validatePicklistConfig(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateBATeamArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateBATeam(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateFormulaArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateFormula(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateTabletArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateTabletDefn(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateTeamAssignmentArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateTeamTablet(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateMatchAssignmentArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateMatchTablet(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validatePlayoffAssignmentArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validatePlayoffAssignment(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateBAMatchArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateBAMatch(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateGraphArray(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireArray(value, path, errors)) {
+        return false;
+    }
+    let ok = true;
+    value.forEach((entry, index) => {
+        ok = validateGraphConfig(entry, `${path}[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function validateLooseArray(value: unknown, path: string, errors: string[]): boolean {
+    return requireArray(value, path, errors);
+}
+
+function validateModelInfo(value: unknown, path: string, errors: string[]): boolean {
+    if (!requireStrictObject(value, path, errors, ["col_descs_"])) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    if (!requireArray(obj.col_descs_, `${path}.col_descs_`, errors)) {
+        return false;
+    }
+    let ok = true;
+    obj.col_descs_.forEach((entry, index) => {
+        ok = validateColumnDesc(entry, `${path}.col_descs_[${index}]`, errors) && ok;
+    });
+    return ok;
+}
+
+function buildResult<T>(value: unknown, validator: Validator<T>, label: string): ValidationResult<T> {
+    const errors: string[] = [];
+    if (validator(value, label, errors) && errors.length === 0) {
+        return { ok: true, value: value as T };
+    }
+    return { ok: false, errors };
+}
+
+function parseJson<T>(packetName: string, payload: string, validator: Validator<T>): ValidationResult<T> {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(payload);
+    }
+    catch (err) {
+        return { ok: false, errors: [`${packetName} is not valid JSON: ${(err as Error).message}`] };
+    }
+    return buildResult(parsed, validator, packetName);
+}
+
+function stringifyJson<T>(packetName: string, value: unknown, validator: Validator<T>): ValidationResult<string> {
+    const validated = buildResult(value, validator, packetName);
+    if (!validated.ok) {
+        return validated;
+    }
+    return { ok: true, value: JSON.stringify(value) };
+}
+
+export function summarizeValidationErrors(errors: string[], limit: number = 8): string {
+    const shown = errors.slice(0, limit);
+    const remaining = errors.length - shown.length;
+    let message = shown.join("\n");
+    if (remaining > 0) {
+        message += `\n...and ${remaining} more`;
+    }
+    return message;
+}
+
+export function validateScoutResultsPayload(value: unknown): ValidationResult<IPCScoutResults> {
+    return buildResult(value, validateScoutResults, "ProvideResults");
+}
+
+export function stringifyScoutResultsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideResults", value, validateScoutResults);
+}
+
+export function parseScoutResultsPayload(payload: string): ValidationResult<IPCScoutResults> {
+    return parseJson("ProvideResults", payload, validateScoutResults);
+}
+
+export function stringifyScoutHelloPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("HelloFromScouter", value, validateScoutHello);
+}
+
+export function parseScoutHelloPayload(payload: string): ValidationResult<{ name: string; purpose: string }> {
+    return parseJson("HelloFromScouter", payload, validateScoutHello);
+}
+
+export function stringifyCoachGraphsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideCoachGraphs", value, (v, p, e) => validateGraphArray(v, p, e));
+}
+
+export function parseCoachGraphsPayload(payload: string): ValidationResult<IPCGraphConfig[]> {
+    return parseJson("ProvideCoachGraphs", payload, (v, p, e) => validateGraphArray(v, p, e));
+}
+
+export function stringifyCoachPicklistsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideCoachPickLists", value, (v, p, e) => validatePicklistArray(v, p, e));
+}
+
+export function parseCoachPicklistsPayload(payload: string): ValidationResult<IPCPickListConfig[]> {
+    return parseJson("ProvideCoachPickLists", payload, (v, p, e) => validatePicklistArray(v, p, e));
+}
+
+export function parseHelloResponsePayload(payload: string, packetName: string): ValidationResult<{ uuid?: string; name: string }> {
+    return parseJson(packetName, payload, validateHelloResponse);
+}
+
+export function stringifyHelloResponsePayload(value: unknown, packetName: string): ValidationResult<string> {
+    return stringifyJson(packetName, value, validateHelloResponse);
+}
+
+export function parseTabletsPayload(payload: string): ValidationResult<IPCTabletDefn[]> {
+    return parseJson("ProvideTablets", payload, (v, p, e) => validateTabletArray(v, p, e));
+}
+
+export function stringifyTabletsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideTablets", value, (v, p, e) => validateTabletArray(v, p, e));
+}
+
+export function parseFormPayload(payload: string, packetName: string): ValidationResult<IPCForm> {
+    return parseJson(packetName, payload, validateForm);
+}
+
+export function stringifyStringArrayPayload(value: unknown, packetName: string): ValidationResult<string> {
+    return stringifyJson(packetName, value, (v, p, e) => validateStringArray(v, p, e, { nonEmpty: true, unique: true }));
+}
+
+export function parseImagesPayload(payload: string): ValidationResult<Record<string, IPCSyncedImageData>> {
+    return parseJson("ProvideImages", payload, validateImagePayloadMap);
+}
+
+export function stringifyImagesPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideImages", value, validateImagePayloadMap);
+}
+
+export function parseScoutResultArrayPayload(payload: string, packetName: string): ValidationResult<IPCScoutResult[]> {
+    return parseJson(packetName, payload, (v, p, e) => validateScoutResultArray(v, p, e));
+}
+
+export function stringifyScoutResultArrayPayload(value: unknown, packetName: string): ValidationResult<string> {
+    return stringifyJson(packetName, value, (v, p, e) => validateScoutResultArray(v, p, e));
+}
+
+export function parseRequestedNamesPayload(payload: string, packetName: string): ValidationResult<string[]> {
+    return parseJson(packetName, payload, (v, p, e) => validateStringArray(v, p, e, { nonEmpty: true, unique: true }));
+}
+
+export function parseTeamAssignmentsPayload(payload: string): ValidationResult<unknown[]> {
+    return parseJson("ProvideTeamList", payload, (v, p, e) => validateTeamAssignmentArray(v, p, e));
+}
+
+export function parseMatchAssignmentsPayload(payload: string): ValidationResult<unknown[]> {
+    return parseJson("ProvideMatchList", payload, (v, p, e) => validateMatchAssignmentArray(v, p, e));
+}
+
+export function stringifyTeamAssignmentsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideTeamList", value, (v, p, e) => validateTeamAssignmentArray(v, p, e));
+}
+
+export function stringifyMatchAssignmentsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideMatchList", value, (v, p, e) => validateMatchAssignmentArray(v, p, e));
+}
+
+export function parsePlayoffAssignmentsPayload(payload: string): ValidationResult<unknown[] | null> {
+    return parseJson("ProvidePlayoffAssignments", payload, (v, p, e) => v === null || validatePlayoffAssignmentArray(v, p, e));
+}
+
+export function stringifyPlayoffAssignmentsPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvidePlayoffAssignments", value, (v, p, e) => v === null || validatePlayoffAssignmentArray(v, p, e));
+}
+
+export function parsePlayoffStatusPayload(payload: string): ValidationResult<IPCPlayoffStatus | null> {
+    return parseJson("ProvidePlayoffStatus", payload, (v, p, e) => v === null || validatePlayoffStatus(v, p, e));
+}
+
+export function stringifyPlayoffStatusPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvidePlayoffStatus", value, (v, p, e) => v === null || validatePlayoffStatus(v, p, e));
+}
+
+export function parseProjectInfoPayload(payload: string): ValidationResult<unknown> {
+    return parseJson("ProvideProject", payload, validateProjectInfo);
+}
+
+export function stringifyProjectInfoPayload(value: unknown): ValidationResult<string> {
+    return stringifyJson("ProvideProject", value, validateProjectInfo);
+}
+
+export function validateScoutSyncPreflight(value: unknown): ValidationResult<IPCScoutResults> {
+    return buildResult(value, validateScoutResults, "ScoutSyncPreflight");
+}
+
+export function validateCoachSyncPreflight(graphs: unknown, picklists: unknown): ValidationResult<true> {
+    const errors: string[] = [];
+    validateGraphArray(graphs, "CoachSyncPreflight.graphs", errors);
+    validatePicklistArray(picklists, "CoachSyncPreflight.picklists", errors);
+    if (Array.isArray(graphs)) {
+        graphs.forEach((graph, index) => {
+            if (isObject(graph) && graph.owner !== "coach") {
+                addError(errors, `CoachSyncPreflight.graphs[${index}].owner`, "must be 'coach'");
+            }
+        });
+    }
+    if (Array.isArray(picklists)) {
+        picklists.forEach((picklist, index) => {
+            if (isObject(picklist) && picklist.owner !== "coach") {
+                addError(errors, `CoachSyncPreflight.picklists[${index}].owner`, "must be 'coach'");
+            }
+        });
+    }
+    if (errors.length > 0) {
+        return { ok: false, errors };
+    }
+    return { ok: true, value: true };
+}

--- a/main/src/test/sccentral-sync-results.test.ts
+++ b/main/src/test/sccentral-sync-results.test.ts
@@ -104,6 +104,36 @@ test('handleProvideResults returns an error packet when processResults fails', a
     expect(reply.payloadAsString()).toBe('team import failed') ;
 }) ;
 
+test('handleProvideResults rejects malformed sync payloads before processing', async () => {
+    const central = createCentral(async () => {
+        throw new Error('should not be called') ;
+    }) ;
+    const packet = new PacketObj(PacketType.ProvideResults, Buffer.from(JSON.stringify({
+        tablet: 'Tablet 41',
+        purpose: 'team',
+        results: [
+            {
+                item: 'st-111',
+                data: [
+                    {
+                        tag: 'cycles',
+                        value: {
+                            type: 'integer',
+                            value: 'bad',
+                        },
+                    },
+                ],
+            },
+        ],
+    }))) ;
+
+    const reply = await central.handleProvideResults(packet) ;
+
+    expect(reply.type_).toBe(PacketType.Error) ;
+    expect(reply.payloadAsString()).toContain('ProvideResults validation failed') ;
+    expect(central.project_.data_mgr_.processResults).not.toHaveBeenCalled() ;
+}) ;
+
 test('handleRequestTeamForm refuses an invalid stored form', () => {
     let formPath = writeTempForm({
         purpose: 'team',

--- a/main/src/test/sccoach-sync-validation.test.ts
+++ b/main/src/test/sccoach-sync-validation.test.ts
@@ -1,0 +1,58 @@
+import { expect, test, vi } from "vitest" ;
+
+vi.mock("electron", () => {
+    return {
+        app: {
+            getVersion: () => '0.0.0',
+        },
+        dialog: {
+            showErrorBox: vi.fn(),
+            showMessageBox: () => Promise.resolve(undefined),
+        },
+        Menu: class {
+        },
+        MenuItem: class {
+        },
+    } ;
+}) ;
+
+import { SCCoach } from "../main/apps/sccoach" ;
+
+test("syncCoach blocks before connect when coach-owned sync config is invalid", () => {
+    const coach = Object.create(SCCoach.prototype) as any ;
+    coach.project_ = {
+        graph_mgr_: {
+            coachConfigs: [
+                {
+                    name: "Bad Graph",
+                    xlabel: "X",
+                    yleft: "Y",
+                    yright: "",
+                    title: "Title",
+                    type: "line",
+                    teams: [111],
+                    leftitems: [],
+                    rightitems: [],
+                    owner: "central",
+                },
+            ],
+        },
+        picklist_mgr_: {
+            coachesPicklists: [],
+        },
+    } ;
+    coach.image_mgr_ = {
+        setExtraImageDirs: vi.fn(),
+    } ;
+    coach.sync_client_ = {
+        connect: vi.fn(() => Promise.resolve()),
+    } ;
+    coach.logger_ = {
+        error: vi.fn(),
+    } ;
+
+    coach["syncCoach"]() ;
+
+    expect(coach.sync_client_.connect).not.toHaveBeenCalled() ;
+    expect(coach.logger_.error).toHaveBeenCalled() ;
+}) ;

--- a/main/src/test/scscout-form-state.test.ts
+++ b/main/src/test/scscout-form-state.test.ts
@@ -123,3 +123,152 @@ test("syncClient blocks before connect when local scout payload is invalid", asy
     expect(connect).not.toHaveBeenCalled() ;
     expect(scout.sent_.some((entry: any) => entry.name === "set-status-title" && entry.payload === "Invalid Local Sync Data")).toBe(true) ;
 }) ;
+
+test("provideResults omits null and undefined fields before persisting", () => {
+    const scout = createScout() ;
+    scout.current_scout_ = "sm-qm-1-1-111" ;
+    scout.logSync = vi.fn() ;
+    scout.writeEventFile = vi.fn() ;
+    scout.logger_ = { silly: vi.fn() } ;
+
+    const input: IPCNamedDataValue[] = [
+        {
+            tag: "valid_integer",
+            value: {
+                type: "integer",
+                value: 3,
+            },
+        },
+        {
+            tag: "null_typed",
+            value: {
+                type: "null",
+                value: null,
+            } as any,
+        },
+        {
+            tag: "missing_value",
+            value: undefined as any,
+        },
+        {
+            tag: "null_value_object",
+            value: null as any,
+        },
+        {
+            tag: "string_null_payload",
+            value: {
+                type: "string",
+                value: null,
+            } as any,
+        },
+    ] ;
+
+    scout.provideResults(input) ;
+
+    expect(scout.info_.results_.length).toBe(1) ;
+    expect(scout.info_.results_[0].item).toBe("sm-qm-1-1-111") ;
+    expect(scout.info_.results_[0].data.map((entry: IPCNamedDataValue) => entry.tag)).toEqual(["valid_integer"]) ;
+}) ;
+
+test("provideResults does not persist when no valid current scout item is active", () => {
+    const scout = createScout() ;
+    scout.current_scout_ = undefined ;
+    scout.logSync = vi.fn() ;
+    scout.writeEventFile = vi.fn() ;
+    scout.logger_ = { silly: vi.fn() } ;
+    scout.resultPromiseResolve_ = vi.fn() ;
+
+    scout.provideResults(createValues("ignored")) ;
+
+    expect(scout.info_.results_.length).toBe(0) ;
+    expect(scout.writeEventFile).not.toHaveBeenCalled() ;
+    expect(scout.resultPromiseResolve_).toBeUndefined() ;
+    expect(scout.sent_.some((entry: any) => entry.name === "set-status-title" && entry.payload === "Invalid Local Scout State")).toBe(true) ;
+}) ;
+
+test("provideResults persists when explicit scoutItem is provided even if current scout is undefined", () => {
+    const scout = createScout() ;
+    scout.current_scout_ = undefined ;
+    scout.logSync = vi.fn() ;
+    scout.writeEventFile = vi.fn() ;
+    scout.logger_ = { silly: vi.fn() } ;
+
+    scout.provideResults(createValues("explicit"), "sm-qm-1-1-111") ;
+
+    expect(scout.info_.results_.length).toBe(1) ;
+    expect(scout.info_.results_[0].item).toBe("sm-qm-1-1-111") ;
+    expect(scout.writeEventFile).toHaveBeenCalled() ;
+}) ;
+
+test("getCurrentResults requests renderer payload for the active scout item", () => {
+    const scout = createScout() ;
+
+    scout["sendToRenderer"] = (_name: string, payload: unknown) => {
+        scout.sent_.push({ name: _name, payload }) ;
+    } ;
+
+    scout["getCurrentResults"]() ;
+
+    const request = scout.sent_.find((entry: any) => entry.name === "request-results") ;
+    expect(request).toBeDefined() ;
+    expect(request.payload).toEqual({ scoutItem: "st-111" }) ;
+}) ;
+
+test("showSyncValidationError includes diagnostic JSON for local sync validation failures", () => {
+    const scout = createScout() ;
+    scout.logSync = vi.fn() ;
+    scout.info_.results_ = [
+        {
+            item: undefined as any,
+            data: createValues("bad"),
+        } as any,
+    ] ;
+
+    scout["showSyncValidationError"]("Invalid Local Sync Data", [
+        "ScoutSyncPreflight.results[0].item expected string but got undefined",
+    ]) ;
+
+    const statusText = scout.sent_.find((entry: any) => entry.name === "set-status-text")?.payload as string ;
+    expect(statusText.includes("Diagnostic JSON (copy/paste):")).toBe(true) ;
+    expect(statusText.includes("\"failingResultIndex\": 0")).toBe(true) ;
+}) ;
+
+test("resetCurrentMatchCmd removes only the active match result and refreshes match form", () => {
+    const scout = createScout() ;
+    scout.current_scout_ = "sm-qm-1-1-111" ;
+    scout.writeEventFile = vi.fn() ;
+    scout.logSync = vi.fn() ;
+    scout.sendForm = vi.fn() ;
+    scout.info_.results_ = [
+        {
+            item: "sm-qm-1-1-111",
+            data: createValues("active"),
+        },
+        {
+            item: "sm-qm-1-2-222",
+            data: createValues("other"),
+        },
+        {
+            item: "st-111",
+            data: createValues("team"),
+        },
+    ] ;
+
+    scout["resetCurrentMatchCmd"]() ;
+
+    expect(scout.info_.results_.map((r: IPCScoutResult) => r.item)).toEqual(["sm-qm-1-2-222", "st-111"]) ;
+    expect(scout.writeEventFile).toHaveBeenCalledTimes(1) ;
+    expect(scout.sendForm).toHaveBeenCalledWith("match") ;
+    expect(scout.sent_.some((entry: any) => entry.name === "send-nav-highlight" && entry.payload === "sm-qm-1-1-111")).toBe(true) ;
+}) ;
+
+test("executeCommand reset-current-match bypasses optionallyGetResults pre-save flow", () => {
+    const scout = createScout() ;
+    scout.optionallyGetResults = vi.fn(() => Promise.resolve()) ;
+    scout.executeCommandInternal = vi.fn() ;
+
+    scout.executeCommand("reset-current-match") ;
+
+    expect(scout.optionallyGetResults).not.toHaveBeenCalled() ;
+    expect(scout.executeCommandInternal).toHaveBeenCalledWith("reset-current-match") ;
+}) ;

--- a/main/src/test/scscout-form-state.test.ts
+++ b/main/src/test/scscout-form-state.test.ts
@@ -212,6 +212,22 @@ test("getCurrentResults requests renderer payload for the active scout item", ()
     const request = scout.sent_.find((entry: any) => entry.name === "request-results") ;
     expect(request).toBeDefined() ;
     expect(request.payload).toEqual({ scoutItem: "st-111" }) ;
+    expect(scout.pending_result_request_item_).toBe("st-111") ;
+}) ;
+
+test("provideResults prefers pending requested scout item when current scout changed", () => {
+    const scout = createScout() ;
+    scout.logSync = vi.fn() ;
+    scout.writeEventFile = vi.fn() ;
+    scout.logger_ = { silly: vi.fn() } ;
+    scout.pending_result_request_item_ = "sm-qm-1-1-111" ;
+    scout.current_scout_ = "sm-qm-1-2-222" ;
+
+    scout.provideResults(createValues("old-match-values")) ;
+
+    expect(scout.info_.results_.length).toBe(1) ;
+    expect(scout.info_.results_[0].item).toBe("sm-qm-1-1-111") ;
+    expect(scout.pending_result_request_item_).toBeUndefined() ;
 }) ;
 
 test("showSyncValidationError includes diagnostic JSON for local sync validation failures", () => {

--- a/main/src/test/scscout-form-state.test.ts
+++ b/main/src/test/scscout-form-state.test.ts
@@ -1,10 +1,11 @@
-import { expect, test } from "vitest" ;
+import { expect, test, vi } from "vitest" ;
 
 import { SCScout, SCScoutInfo } from "../main/apps/scscout" ;
 import { IPCNamedDataValue, IPCScoutResult } from "../shared/ipc" ;
 
 function createScout() : any {
     const scout = Object.create(SCScout.prototype) as any ;
+    scout.sent_ = [] ;
     scout.info_ = new SCScoutInfo() ;
     scout.info_.uuid_ = "event-uuid" ;
     scout.info_.tablet_ = "Tablet 41" ;
@@ -15,6 +16,7 @@ function createScout() : any {
     scout.alliance_ = "blue" ;
     scout.sendToRenderer = (_name: string, payload: unknown) => {
         scout.lastPayload_ = payload ;
+        scout.sent_.push({ name: _name, payload }) ;
     } ;
     return scout ;
 }
@@ -83,4 +85,41 @@ test("getTeamResultFromCache returns a cloned result", () => {
     cached.data[0].value.value = "mutated" ;
 
     expect(scout.info_.team_results_cache_[0].data[0].value.value).toBe("team-111") ;
+}) ;
+
+test("syncClient blocks before connect when local scout payload is invalid", async () => {
+    const scout = createScout() ;
+    scout.info_.purpose_ = "team" ;
+    scout.info_.results_ = [
+        {
+            item: "st-111",
+            data: [
+                {
+                    tag: "cycles",
+                    value: {
+                        type: "integer",
+                        value: "bad",
+                    },
+                },
+            ],
+        },
+    ] ;
+
+    const connect = vi.fn(() => Promise.resolve()) ;
+    const conn = {
+        name: () => "test-conn",
+        setTraceContext: vi.fn(),
+        connect,
+        on: vi.fn(),
+    } ;
+
+    scout.optionallyGetResults = vi.fn(() => Promise.resolve()) ;
+    scout.logSync = vi.fn() ;
+    scout.getSyncStateSnapshot = vi.fn(() => ({})) ;
+
+    scout["syncClient"](conn as any) ;
+    await Promise.resolve() ;
+
+    expect(connect).not.toHaveBeenCalled() ;
+    expect(scout.sent_.some((entry: any) => entry.name === "set-status-title" && entry.payload === "Invalid Local Sync Data")).toBe(true) ;
 }) ;

--- a/main/src/test/synccontract.test.ts
+++ b/main/src/test/synccontract.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest" ;
+
+import {
+    parseProjectInfoPayload,
+    stringifyCoachGraphsPayload,
+    stringifyScoutResultsPayload,
+    validateCoachSyncPreflight,
+} from "../shared/synccontract" ;
+
+test("stringifyScoutResultsPayload accepts a valid scout payload", () => {
+    const result = stringifyScoutResultsPayload({
+        tablet: "Tablet 41",
+        purpose: "team",
+        results: [
+            {
+                item: "st-111",
+                data: [
+                    {
+                        tag: "notes",
+                        value: {
+                            type: "string",
+                            value: "ready",
+                        },
+                    },
+                ],
+            },
+        ],
+    }) ;
+
+    expect(result.ok).toBe(true) ;
+}) ;
+
+test("stringifyScoutResultsPayload rejects duplicate result items", () => {
+    const result = stringifyScoutResultsPayload({
+        tablet: "Tablet 41",
+        purpose: "team",
+        results: [
+            { item: "st-111", data: [] },
+            { item: "st-111", data: [] },
+        ],
+    }) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("duplicates item 'st-111'") ;
+    }
+}) ;
+
+test("stringifyScoutResultsPayload rejects mismatched typed values", () => {
+    const result = stringifyScoutResultsPayload({
+        tablet: "Tablet 41",
+        purpose: "team",
+        results: [
+            {
+                item: "st-111",
+                data: [
+                    {
+                        tag: "cycles",
+                        value: {
+                            type: "integer",
+                            value: "five",
+                        },
+                    },
+                ],
+            },
+        ],
+    }) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("expected finite number") ;
+    }
+}) ;
+
+test("validateCoachSyncPreflight rejects non-coach-owned graph payloads", () => {
+    const result = validateCoachSyncPreflight([
+        {
+            name: "Graph",
+            xlabel: "X",
+            yleft: "Y",
+            yright: "",
+            title: "Graph",
+            type: "line",
+            teams: [111],
+            leftitems: [],
+            rightitems: [],
+            owner: "central",
+        },
+    ], []) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("must be 'coach'") ;
+    }
+}) ;
+
+test("stringifyCoachGraphsPayload rejects unknown keys", () => {
+    const result = stringifyCoachGraphsPayload([
+        {
+            name: "Graph",
+            xlabel: "X",
+            yleft: "Y",
+            yright: "",
+            title: "Graph",
+            type: "line",
+            teams: [111],
+            leftitems: [],
+            rightitems: [],
+            owner: "coach",
+            unexpected: true,
+        },
+    ]) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("unknown key 'unexpected'") ;
+    }
+}) ;
+
+test("parseProjectInfoPayload rejects malformed project metadata", () => {
+    const result = parseProjectInfoPayload(JSON.stringify({
+        uuid_: "event-uuid",
+        locked_: true,
+        hidden_hints_: [],
+        data_info_: {},
+    })) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("data_info_.scouted_team_ expected array") ;
+        expect(result.errors.join("\n")).toContain("dataset_info_ expected object") ;
+    }
+}) ;

--- a/main/src/test/synccontract.test.ts
+++ b/main/src/test/synccontract.test.ts
@@ -72,6 +72,45 @@ test("stringifyScoutResultsPayload rejects mismatched typed values", () => {
     }
 }) ;
 
+test("stringifyScoutResultsPayload includes tag preview for missing result item", () => {
+    const result = stringifyScoutResultsPayload({
+        tablet: "Tablet 41",
+        purpose: "match",
+        results: [
+            {
+                data: [
+                    {
+                        tag: "auto_notes",
+                        value: {
+                            type: "string",
+                            value: "",
+                        },
+                    },
+                    {
+                        tag: "defense_rating",
+                        value: {
+                            type: "integer",
+                            value: 3,
+                        },
+                    },
+                    {
+                        tag: "climb",
+                        value: {
+                            type: "string",
+                            value: "yes",
+                        },
+                    },
+                ],
+            },
+        ],
+    }) ;
+
+    expect(result.ok).toBe(false) ;
+    if (!result.ok) {
+        expect(result.errors.join("\n")).toContain("results[0] is missing scout item id; data tags: auto_notes, defense_rating, climb") ;
+    }
+}) ;
+
 test("validateCoachSyncPreflight rejects non-coach-owned graph payloads", () => {
     const result = validateCoachSyncPreflight([
         {

--- a/renderer/src/views/forms/scoutformview.ts
+++ b/renderer/src/views/forms/scoutformview.ts
@@ -302,15 +302,16 @@ export class XeroScoutFormView extends XeroView {
         }
     }
 
-    private scoutDataConfirmed(changed: boolean) {
-        this.request('provide-result', this.data_!.values) ;
+    private scoutDataConfirmed(changed: boolean, scoutItem?: string) {
+        const targetScoutItem = scoutItem?.length ? scoutItem : this.getScoutItemId() ;
+        this.request('provide-result', { scoutItem: targetScoutItem, data: this.data_!.values }) ;
         this.clearDraft() ;
     }
 
-    private provideResults() {
+    private provideResults(args?: { scoutItem?: string }) {
         // This extracts the results from the current section
         this.beforeSectionChanged(this.tabbed_ctrl_!.selectedPageNumber, -1) ;     
-        this.scoutDataConfirmed(true) ;   
+        this.scoutDataConfirmed(true, args?.scoutItem) ;   
     }
 
     private setCurrentSectionByIndex(sectionIndex: number) : boolean {
@@ -323,6 +324,12 @@ export class XeroScoutFormView extends XeroView {
     }    
 
     private receivedForm(args: IPCFormScoutData) : void {
+        this.resetAllTimersAndStopwatches() ;
+        for (let page of this.section_pages_) {
+            page.close() ;
+        }
+        this.section_pages_ = [] ;
+
         this.form_info_ = args ;
         this.data_ = new XeroFormDataValues() ;
         this.preview_restored_from_db_ = false ;

--- a/renderer/src/views/matchstatus.ts
+++ b/renderer/src/views/matchstatus.ts
@@ -13,6 +13,16 @@ export class XeroMatchStatus extends XeroView {
         this.request('get-match-status', args) ;
     }
 
+    public override close(): void {
+        if (this.table_) {
+            this.table_.destroy() ;
+            this.table_ = undefined ;
+        }
+
+        this.main_div_ = undefined ;
+        super.close() ;
+    }
+
     private static mapMatchType(mtype: string) : number {
         let ret= -1 ;
 
@@ -66,6 +76,11 @@ export class XeroMatchStatus extends XeroView {
     }
 
     private receivedMatchStatus( args: any) {
+        if (this.table_) {
+            this.table_.setData(args) ;
+            return ;
+        }
+
         this.main_div_ = document.createElement('div') ;
         this.main_div_.classList.add('xero-teamstatus-view') ;
         this.elem.appendChild(this.main_div_) ;

--- a/renderer/src/views/selecttablet/selecttabletdialog.ts
+++ b/renderer/src/views/selecttablet/selecttabletdialog.ts
@@ -1,4 +1,4 @@
-import { CellComponent, RowComponent, TabulatorFull } from "tabulator-tables";
+import { RowComponent, TabulatorFull } from "tabulator-tables";
 import { IPCTabletDefn } from "../../shared/ipc.js";
 import { XeroDialog } from "../../widgets/xerodialog.js";
 
@@ -30,14 +30,15 @@ export class SelectTabletDialog extends XeroDialog {
                     { title: 'Tablet Type', field: 'purpose', width: 200 },
                 ],
                 layout: 'fitColumns',
-                rowClick: (_e: Event, row: RowComponent) => {
-                    let data = row.getData() as IPCTabletDefn ;
-                    this.selected_tablet_ = {
-                        name: data.name,
-                        purpose: data.purpose,
-                    } ;
-                },
             }) ;
+
+        this.table_.on('rowClick', (_e: UIEvent, row: RowComponent) => {
+            let data = row.getData() as IPCTabletDefn ;
+            this.selected_tablet_ = {
+                name: data.name,
+                purpose: data.purpose,
+            } ;
+        }) ;
 
         pdiv.appendChild(div) ;
     }    

--- a/renderer/src/views/teamstatus.ts
+++ b/renderer/src/views/teamstatus.ts
@@ -13,7 +13,22 @@ export class XeroTeamStatus extends XeroView {
         this.request('get-team-status', args) ;
     }
 
+    public override close(): void {
+        if (this.table_) {
+            this.table_.destroy() ;
+            this.table_ = undefined ;
+        }
+
+        this.main_div_ = undefined ;
+        super.close() ;
+    }
+
     private receivedTeamStatus( args: any) {
+        if (this.table_) {
+            this.table_.setData(args) ;
+            return ;
+        }
+
         this.main_div_ = document.createElement('div') ;
         this.main_div_.classList.add('xero-teamstatus-view') ;
         this.elem.appendChild(this.main_div_) ;


### PR DESCRIPTION
his branch consolidates fixes for scouting sync reliability, contract enforcement, and renderer state lifecycle issues across Scout, Central, and shared sync paths.

  It includes:

  - Strict JSON sync contract validation and improved local/remote sync diagnostics.
  - Better scout sync error previews to make invalid payloads actionable.
  - Fixes for core sync/data issues, including result attribution race conditions when switching matches.
  - Updated cable sync behavior to consistently use 192.168.1.1.
  - Additional fixes to eliminate stale/bleeding data behavior in scouting flows.
  - Renderer lifecycle fixes to prevent duplicate status tables in Central Match/Team Status views.

  Net result:

  - Sync failures now fail earlier with clearer reasons.
  - Match/team result writes are correctly attributed during rapid UI transitions.
  - Central status views update idempotently without duplicate table/footer artifacts.